### PR TITLE
Add anchor links to headings

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -178,6 +178,43 @@ html {
     text-underline-offset: 5px;
   }
 
+  /* Scroll offset for anchor links */
+  h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
+    scroll-margin-top: 1rem;
+  }
+
+  /* Heading anchor links */
+  .heading-anchor {
+    margin-left: 0.35em;
+    color: var(--color-gray-300);
+    text-decoration: none;
+    font-weight: 400;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+
+  h1:hover .heading-anchor,
+  h2:hover .heading-anchor,
+  h3:hover .heading-anchor,
+  h4:hover .heading-anchor,
+  h5:hover .heading-anchor,
+  h6:hover .heading-anchor,
+  .heading-anchor:focus {
+    opacity: 1;
+  }
+
+  .heading-anchor:hover {
+    color: var(--color-blue-500);
+  }
+
+  .dark .heading-anchor {
+    color: var(--color-gray-600);
+  }
+
+  .dark .heading-anchor:hover {
+    color: var(--color-blue-400);
+  }
+
   /* Reset letter-spacing for monospace/Source Code Pro */
   .font-mono,
   code,

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,4 @@
+<h{{ .Level }} id="{{ .Anchor }}"{{ with .Attributes.class }} class="{{ . }}"{{ end }}>
+  {{- .Text -}}
+  <a class="heading-anchor" href="#{{ .Anchor }}" aria-label="Link to this section: {{ .Text | plainify }}">#</a>
+</h{{ .Level }}>

--- a/layouts/categories/term.html
+++ b/layouts/categories/term.html
@@ -27,9 +27,7 @@
   {{ $software := where .Pages "Section" "software" }}
   {{ if gt (len $software) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      {{ .Title }} Software
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "%s Software" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $software }}
@@ -42,9 +40,7 @@
   {{ $blog := where .Pages "Section" "blog" }}
   {{ if gt (len $blog) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      {{ .Title }} Blog Posts
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "%s Blog Posts" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $blog.ByDate.Reverse }}
@@ -57,9 +53,7 @@
   {{ $events := where .Pages "Section" "events" }}
   {{ if gt (len $events) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      {{ .Title }} Events
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "%s Events" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $events }}
@@ -72,9 +66,7 @@
   {{ $resources := where .Pages "Section" "resources" }}
   {{ if gt (len $resources) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      {{ .Title }} Resources
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "%s Resources" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $resources.ByDate.Reverse }}

--- a/layouts/events/term.html
+++ b/layouts/events/term.html
@@ -142,9 +142,7 @@
   {{ $people := .GetTerms "people" }}
   {{ if $people }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Attendees
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" "Attendees" "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-6 gap-y-10 mx-2 md:mx-0 mb-6">
@@ -158,9 +156,7 @@
   {{ $software := .GetTerms "software" }}
   {{ if $software }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Featured software
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" "Featured software" "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mx-2 md:mx-0 mb-6">
@@ -174,9 +170,7 @@
   {{ $resources := .GetTerms "resources" }}
   {{ if $resources }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Resources from this event
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" "Resources from this event" "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mx-2 md:mx-0 mb-6">

--- a/layouts/events/terms.html
+++ b/layouts/events/terms.html
@@ -46,9 +46,7 @@
   <!-- Current Events Section -->
   {{ if gt (len $currentEvents) 0 }}
     <div class="flex flex-col gap-y-4">
-      <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200">
-        Current Events
-      </h2>
+      {{ partial "heading.html" (dict "level" 2 "text" "Current Events" "class" "text-2xl font-medium text-gray-800 dark:text-gray-200") }}
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {{ range $currentEvents }}
           {{ partial "item.html" (dict "page" . "hide-badge" "true") }}
@@ -60,9 +58,7 @@
   <!-- Upcoming Events Section -->
   {{ if gt (len $upcomingEvents) 0 }}
     <div class="flex flex-col gap-y-4">
-      <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200">
-        Upcoming Events
-      </h2>
+      {{ partial "heading.html" (dict "level" 2 "text" "Upcoming Events" "class" "text-2xl font-medium text-gray-800 dark:text-gray-200") }}
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {{ range $upcomingEvents.ByParam "start_date" }}
           {{ partial "item.html" (dict "page" . "hide-badge" "true") }}
@@ -74,9 +70,7 @@
   <!-- Past Events Section -->
   {{ if gt (len $pastEvents) 0 }}
     <div class="flex flex-col gap-y-4">
-      <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200">
-        Past Events
-      </h2>
+      {{ partial "heading.html" (dict "level" 2 "text" "Past Events" "class" "text-2xl font-medium text-gray-800 dark:text-gray-200") }}
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {{ range ($pastEvents.ByParam "start_date").Reverse }}
           {{ partial "item.html" (dict "page" . "hide-badge" "true") }}

--- a/layouts/languages/term.html
+++ b/layouts/languages/term.html
@@ -10,9 +10,7 @@
   {{ $software := where .Pages "Section" "software" }}
   {{ if gt (len $software) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      {{ .Title }} Software
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "%s Software" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $software }}
@@ -25,9 +23,7 @@
   {{ $blog := where .Pages "Section" "blog" }}
   {{ if gt (len $blog) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      {{ .Title }} Blog Posts
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "%s Blog Posts" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $blog.ByDate.Reverse }}
@@ -40,9 +36,7 @@
   {{ $events := where .Pages "Section" "events" }}
   {{ if gt (len $events) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      {{ .Title }} Events
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "%s Events" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $events }}
@@ -55,9 +49,7 @@
   {{ $resources := where .Pages "Section" "resources" }}
   {{ if gt (len $resources) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      {{ .Title }} Resources
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "%s Resources" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $resources.ByDate.Reverse }}

--- a/layouts/partials/heading.html
+++ b/layouts/partials/heading.html
@@ -1,0 +1,8 @@
+{{- $level := .level | default 2 -}}
+{{- $text := .text -}}
+{{- $id := $text | anchorize -}}
+{{- $class := .class | default "" -}}
+<h{{ $level }} id="{{ $id }}"{{ with $class }} class="{{ . }}"{{ end }}>
+  {{- $text -}}
+  <a class="heading-anchor" href="#{{ $id }}" aria-label="Link to this section: {{ $text }}">#</a>
+</h{{ $level }}>

--- a/layouts/people/term.html
+++ b/layouts/people/term.html
@@ -137,9 +137,7 @@
   <!-- People in this Team -->
   {{ with .Params.people }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      People
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" "People" "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-x-6 gap-y-10 mx-2 md:mx-0 mb-6">
@@ -164,9 +162,7 @@
   {{ end }}
   {{ if gt (len $software) 0 }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Software by {{ .Title }}
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "Software by %s" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mx-2 md:mx-0 mb-6">
@@ -188,9 +184,7 @@
   {{ end }}
   {{ if gt (len $events) 0 }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Events attended by {{ .Title }}
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "Events attended by %s" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mx-2 md:mx-0 mb-6">
@@ -215,9 +209,7 @@
   {{ end }}
   {{ if gt (len $combined) 0 }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Posts and resources by {{ .Title }}
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "Posts and resources by %s" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mx-2 md:mx-0 mb-6">

--- a/layouts/resources/term.html
+++ b/layouts/resources/term.html
@@ -377,7 +377,7 @@
     <div class="flex flex-col lg:flex-row gap-8 mt-8 mx-2 md:mx-0">
       <div class="flex-1 min-w-0">
         <div class="w-full prose">
-          <h2 id="transcript" class="">Transcript</h2>
+          {{ partial "heading.html" (dict "level" 2 "text" "Transcript") }}
           <p class="mb-6 italic">This transcript was generated automatically and may contain errors.</p>
           <div data-pagefind-body id="video-transcript"
             class="[&_a[data-t]]:hover:bg-gray-100 [&_a[data-t]]:hover:no-underline! [&_a[data-t]]:rounded [&_a[data-t]]:text-inherit! [&_a[data-t]]:transition-colors [&_a[data-t]]:duration-200">
@@ -441,9 +441,7 @@
     <!-- Software used in this Resource -->
     {{ if $software }}
     <div class="mt-8 mb-6 mx-2 md:mx-0">
-      <h2 id="featured-software" class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-        Featured software
-      </h2>
+      {{ partial "heading.html" (dict "level" 2 "text" "Featured software" "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mx-2 md:mx-0 mb-6">
@@ -456,9 +454,7 @@
     <!-- Related Resources -->
     {{ if $resources }}
     <div class="mt-8 mb-6 mx-2 md:mx-0">
-      <h2 id="related-resources" class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-        Related resources
-      </h2>
+      {{ partial "heading.html" (dict "level" 2 "text" "Related resources" "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mx-2 md:mx-0 mb-6">
@@ -471,9 +467,7 @@
     <!-- Events related to this Resource -->
     {{ if $events }}
     <div class="mt-8 mb-6 mx-2 md:mx-0">
-      <h2 id="related-events" class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-        Related events
-      </h2>
+      {{ partial "heading.html" (dict "level" 2 "text" "Related events" "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mx-2 md:mx-0 mb-6">

--- a/layouts/software/term.html
+++ b/layouts/software/term.html
@@ -92,9 +92,7 @@
   {{ $people := .GetTerms "people" }}
   {{ if $people }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium dark:text-gray-200 mb-4">
-      Contributors
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" "Contributors" "class" "text-2xl font-medium dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 gap-1 gap-y-10 mx-2 md:mx-0 mb-6">
@@ -108,9 +106,7 @@
   {{ $events := where .Pages "Section" "events" }}
   {{ if gt (len $events) 0 }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Events featuring {{ .Title }}
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "Events featuring %s" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mx-2 md:mx-0 mb-6">
@@ -124,9 +120,7 @@
   {{ $resources := where .Pages "Section" "resources" }}
   {{ if gt (len $resources) 0 }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Resources featuring {{ .Title }}
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "Resources featuring %s" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mx-2 md:mx-0 mb-6">
@@ -140,9 +134,7 @@
   {{ $posts := where .Pages "Section" "blog" }}
   {{ if gt (len $posts) 0 }}
   <div class="mt-8 mb-6 mx-2 md:mx-0">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Posts about {{ .Title }}
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "Posts about %s" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
 
   <div class="flex flex-col">

--- a/layouts/tags/term.html
+++ b/layouts/tags/term.html
@@ -10,9 +10,7 @@
   {{ $software := where .Pages "Section" "software" }}
   {{ if gt (len $software) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Software tagged {{ .Title }}
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "Software tagged %s" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $software }}
@@ -25,9 +23,7 @@
   {{ $blog := where .Pages "Section" "blog" }}
   {{ if gt (len $blog) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Blog Posts tagged {{ .Title }}
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "Blog Posts tagged %s" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $blog.ByDate.Reverse }}
@@ -40,9 +36,7 @@
   {{ $events := where .Pages "Section" "events" }}
   {{ if gt (len $events) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Events tagged {{ .Title }}
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "Events tagged %s" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $events }}
@@ -55,9 +49,7 @@
   {{ $resources := where .Pages "Section" "resources" }}
   {{ if gt (len $resources) 0 }}
   <div class="mt-8 mb-6">
-    <h2 class="text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4">
-      Resources tagged {{ .Title }}
-    </h2>
+    {{ partial "heading.html" (dict "level" 2 "text" (printf "Resources tagged %s" .Title) "class" "text-2xl font-medium text-gray-800 dark:text-gray-200 mb-4") }}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     {{ range $resources.ByDate.Reverse }}


### PR DESCRIPTION
## Summary

- Adds clickable `#` anchor links to all headings site-wide, for both Markdown content and template-rendered section headings
- Markdown headings get anchors via a `render-heading.html` hook; template headings use a new `heading.html` partial
- Anchors are hidden by default and fade in on hover/focus, following Posit's flat/minimal design

## Details

**New files:**
- `layouts/_default/_markup/render-heading.html` — Hugo render hook for Markdown headings
- `layouts/partials/heading.html` — Reusable partial for template headings (accepts `level`, `text`, `class`)

**CSS additions (`assets/css/main.css`):**
- `scroll-margin-top: 1rem` on headings with IDs for proper anchor scroll offset
- `.heading-anchor` styles: opacity transition, brand-compliant colors (gray-300 resting, blue-500 hover), dark mode variants

**Template updates** — converted `<h2>` section headings to use the partial in:
- `events/terms.html`, `events/term.html`
- `software/term.html`
- `people/term.html`
- `categories/term.html`, `languages/term.html`, `tags/term.html`
- `resources/term.html`

Closes #18

## Test plan

- [x] Hover over a heading in a blog post — `#` link appears
- [x] Click the `#` — URL updates with anchor hash, page scrolls correctly
- [x] Copy URL with `#anchor` and open in new tab — lands at the correct heading
- [x] Verify dark mode renders correct colors
- [x] Verify TOC sidebar links still work on blog posts and resource pages
- [x] Check section headings on term pages (e.g., /software/ggplot2/, /people/hadley-wickham/)
- [x] Tab to an anchor link — visible on focus (keyboard accessibility)