### PR TITLE
Add descriptions to blog posts

### DIFF
--- a/content/blog/anscombes-quartet/index.ipynb
+++ b/content/blog/anscombes-quartet/index.ipynb
@@ -4,17 +4,7 @@
    "cell_type": "markdown",
    "id": "787b9a61",
    "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Seeing Beyond Statistics: Anscombe's Quartet and the Power of Graphs\"\n",
-    "people: [\"Jeroen Janssens\"]\n",
-    "date: 2024-07-02\n",
-    "image: ruthson-zimmerman-FVwG5OzPuzo-unsplash.jpg\n",
-    "image-alt: \"Hands typing on a laptop showing a data dashboard on the screen\"\n",
-    "software: [\"plotnine\"]\n",
-    "languages: [\"Python\"]\n",
-    "---"
-   ]
+   "source": "---\ntitle: \"Seeing Beyond Statistics: Anscombe's Quartet and the Power of Graphs\"\ndescription: \"Why visualizing data matters: recreating Anscombe's Quartet with Plotnine and Polars.\"\nauto-description: true\npeople: [\"Jeroen Janssens\"]\ndate: 2024-07-02\nimage: ruthson-zimmerman-FVwG5OzPuzo-unsplash.jpg\nimage-alt: \"Hands typing on a laptop showing a data dashboard on the screen\"\nsoftware: [\"plotnine\"]\nlanguages: [\"Python\"]\n---"
   },
   {
    "attachments": {},

--- a/content/blog/anscombes-quartet/index.md
+++ b/content/blog/anscombes-quartet/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Seeing Beyond Statistics: Anscombe''s Quartet and the Power of Graphs'
+description: "Why visualizing data matters: recreating Anscombe's Quartet with Plotnine and Polars."
+auto-description: true
 people:
   - Jeroen Janssens
 date: '2024-07-02'

--- a/content/blog/education/2020-07-13-teaching-the-tidyverse-in-2020-part-1-getting-started/index.Rmarkdown
+++ b/content/blog/education/2020-07-13-teaching-the-tidyverse-in-2020-part-1-getting-started/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: 'Teaching the Tidyverse in 2020 - Part 1: Getting started'
+description: "Getting started teaching the tidyverse in 2020: loading packages, managing environments, and using palmerpenguins."
+auto-description: true
 date: '2020-07-13'
 slug: teaching-the-tidyverse-in-2020-part-1-getting-started
 categories:

--- a/content/blog/education/2020-07-13-teaching-the-tidyverse-in-2020-part-1-getting-started/index.markdown
+++ b/content/blog/education/2020-07-13-teaching-the-tidyverse-in-2020-part-1-getting-started/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: 'Teaching the Tidyverse in 2020 - Part 1: Getting started'
+description: "Getting started teaching the tidyverse in 2020: loading packages, managing environments, and using palmerpenguins."
+auto-description: true
 date: '2020-07-13'
 slug: teaching-the-tidyverse-in-2020-part-1-getting-started
 categories:

--- a/content/blog/education/2020-07-15-teaching-the-tidyverse-in-2020-part-2-data-visualisation/index.Rmarkdown
+++ b/content/blog/education/2020-07-15-teaching-the-tidyverse-in-2020-part-2-data-visualisation/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: 'Teaching the Tidyverse in 2020 - Part 2: Data visualisation'
+description: "Teaching data visualization in 2020: new ggplot2 features for introductory curricula."
+auto-description: true
 date: '2020-07-15'
 slug: teaching-the-tidyverse-in-2020-part-2-data-visualisation
 categories:

--- a/content/blog/education/2020-07-15-teaching-the-tidyverse-in-2020-part-2-data-visualisation/index.markdown
+++ b/content/blog/education/2020-07-15-teaching-the-tidyverse-in-2020-part-2-data-visualisation/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: 'Teaching the Tidyverse in 2020 - Part 2: Data visualisation'
+description: "Teaching data visualization in 2020: new ggplot2 features for introductory curricula."
+auto-description: true
 date: '2020-07-15'
 slug: teaching-the-tidyverse-in-2020-part-2-data-visualisation
 categories:

--- a/content/blog/education/2020-07-17-teaching-the-tidyverse-in-2020-part-3-data-wrangling-and-tidying/index.Rmarkdown
+++ b/content/blog/education/2020-07-17-teaching-the-tidyverse-in-2020-part-3-data-wrangling-and-tidying/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: 'Teaching the Tidyverse in 2020 - Part 3: Data wrangling and tidying'
+description: "Teaching data wrangling in 2020: pivot_longer/wider, across(), and rowwise() in dplyr and tidyr."
+auto-description: true
 date: '2020-07-17'
 slug: teaching-the-tidyverse-in-2020-part-3-data-wrangling-and-tidying
 categories:

--- a/content/blog/education/2020-07-17-teaching-the-tidyverse-in-2020-part-3-data-wrangling-and-tidying/index.markdown
+++ b/content/blog/education/2020-07-17-teaching-the-tidyverse-in-2020-part-3-data-wrangling-and-tidying/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: 'Teaching the Tidyverse in 2020 - Part 3: Data wrangling and tidying'
+description: "Teaching data wrangling in 2020: pivot_longer/wider, across(), and rowwise() in dplyr and tidyr."
+auto-description: true
 date: '2020-07-17'
 slug: teaching-the-tidyverse-in-2020-part-3-data-wrangling-and-tidying
 categories:

--- a/content/blog/education/2020-07-19-teaching-the-tidyverse-in-2020-part-4-when-to-purrr/index.Rmarkdown
+++ b/content/blog/education/2020-07-19-teaching-the-tidyverse-in-2020-part-4-when-to-purrr/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: 'Teaching the Tidyverse in 2020 - Part 4: When to purrr?'
+description: "When to use purrr? Modern tidyverse alternatives for reading multiple files and fitting models."
+auto-description: true
 date: '2020-07-19'
 slug: teaching-the-tidyverse-in-2020-part-4-when-to-purrr
 categories:

--- a/content/blog/education/2020-07-19-teaching-the-tidyverse-in-2020-part-4-when-to-purrr/index.markdown
+++ b/content/blog/education/2020-07-19-teaching-the-tidyverse-in-2020-part-4-when-to-purrr/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: 'Teaching the Tidyverse in 2020 - Part 4: When to purrr?'
+description: "When to use purrr? Modern tidyverse alternatives for reading multiple files and fitting models."
+auto-description: true
 date: '2020-07-19'
 slug: teaching-the-tidyverse-in-2020-part-4-when-to-purrr
 categories:

--- a/content/blog/education/2020-08-17-spreadsheet-workflows-using-r/index.Rmarkdown
+++ b/content/blog/education/2020-08-17-spreadsheet-workflows-using-r/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: Spreadsheet workflows in R
+description: "Translate common spreadsheet workflows—IF statements, VLOOKUP, pivot tables—into tidyverse code."
+auto-description: true
 date: '2020-08-17'
 slug: spreadsheets-using-r
 categories:

--- a/content/blog/education/2020-08-17-spreadsheet-workflows-using-r/index.markdown
+++ b/content/blog/education/2020-08-17-spreadsheet-workflows-using-r/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: Spreadsheet workflows in R
+description: "Translate common spreadsheet workflows—IF statements, VLOOKUP, pivot tables—into tidyverse code."
+auto-description: true
 date: '2020-08-17'
 slug: spreadsheets-using-r
 categories:

--- a/content/blog/great-tables/bring-your-own-df/index.md
+++ b/content/blog/great-tables/bring-your-own-df/index.md
@@ -1,5 +1,7 @@
 ---
 title: Great Tables is now BYODF (Bring Your Own DataFrame)
+description: "Great Tables v0.5.0 makes Pandas optional—use Polars without pulling in extra dependencies."
+auto-description: true
 people:
   - Michael Chow
 date: '2024-04-24T00:00:00.000Z'

--- a/content/blog/great-tables/bring-your-own-df/index.qmd
+++ b/content/blog/great-tables/bring-your-own-df/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Great Tables is now BYODF (Bring Your Own DataFrame)
+description: "Great Tables v0.5.0 makes Pandas optional—use Polars without pulling in extra dependencies."
+auto-description: true
 people:
   - Michael Chow
 date: '2024-04-24'

--- a/content/blog/great-tables/design-philosophy/index.md
+++ b/content/blog/great-tables/design-philosophy/index.md
@@ -1,5 +1,7 @@
 ---
 title: The Design Philosophy of Great Tables
+description: "Why tables matter: 5,000 years of table design and how Great Tables solves the modern dilemma."
+auto-description: true
 people:
   - Rich Iannone
   - Michael Chow

--- a/content/blog/great-tables/design-philosophy/index.qmd
+++ b/content/blog/great-tables/design-philosophy/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: The Design Philosophy of Great Tables
+description: "Why tables matter: 5,000 years of table design and how Great Tables solves the modern dilemma."
+auto-description: true
 people:
   - Rich Iannone
   - Michael Chow

--- a/content/blog/great-tables/introduction-0.12.0/index.md
+++ b/content/blog/great-tables/introduction-0.12.0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.12.0`: Google Fonts and zebra stripes'
+description: "New in Great Tables v0.12.0: Google Fonts via google_font() and zebra striping with opt_row_striping()."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-09-30T00:00:00.000Z'

--- a/content/blog/great-tables/introduction-0.12.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.12.0/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.12.0`: Google Fonts and zebra stripes'
+description: "New in Great Tables v0.12.0: Google Fonts via google_font() and zebra striping with opt_row_striping()."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-09-30'

--- a/content/blog/great-tables/introduction-0.13.0/index.md
+++ b/content/blog/great-tables/introduction-0.13.0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.13.0`: Applying styles to all table locations'
+description: "Great Tables v0.13.0 brings styling to all table locations via expanded loc.*() methods."
+auto-description: true
 people:
   - Rich Iannone
   - Michael Chow

--- a/content/blog/great-tables/introduction-0.13.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.13.0/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.13.0`: Applying styles to all table locations'
+description: "Great Tables v0.13.0 brings styling to all table locations via expanded loc.*() methods."
+auto-description: true
 people:
   - Rich Iannone
   - Michael Chow

--- a/content/blog/great-tables/introduction-0.15.0/index.md
+++ b/content/blog/great-tables/introduction-0.15.0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.15.0`: Flags, Icons, and Other Formatting Goodies'
+description: "New in Great Tables v0.15.0: country flag icons with fmt_flag(), Font Awesome icons, and accounting notation."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-12-19T00:00:00.000Z'

--- a/content/blog/great-tables/introduction-0.15.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.15.0/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.15.0`: Flags, Icons, and Other Formatting Goodies'
+description: "New in Great Tables v0.15.0: country flag icons with fmt_flag(), Font Awesome icons, and accounting notation."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-12-19'

--- a/content/blog/great-tables/introduction-0.18.0/index.md
+++ b/content/blog/great-tables/introduction-0.18.0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.18.0`: Easy Column Spanners and More!'
+description: "New in Great Tables v0.18.0: automatic column spanners with tab_spanner_delim(), boolean formatting, and rotated labels."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-07-18T00:00:00.000Z'

--- a/content/blog/great-tables/introduction-0.18.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.18.0/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.18.0`: Easy Column Spanners and More!'
+description: "New in Great Tables v0.18.0: automatic column spanners with tab_spanner_delim(), boolean formatting, and rotated labels."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-07-18'

--- a/content/blog/great-tables/introduction-0.2.0/index.md
+++ b/content/blog/great-tables/introduction-0.2.0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.2.0`: Easy Data Coloring'
+description: "New in Great Tables v0.2.0: data_color() for automatic cell coloring based on values."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-01-24T00:00:00.000Z'

--- a/content/blog/great-tables/introduction-0.2.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.2.0/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.2.0`: Easy Data Coloring'
+description: "New in Great Tables v0.2.0: data_color() for automatic cell coloring based on values."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-01-24'

--- a/content/blog/great-tables/introduction-0.3.0/index.md
+++ b/content/blog/great-tables/introduction-0.3.0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.3.0`: So Many Style Options!'
+description: "New in Great Tables v0.3.0: control column widths, style entire tables, and use system fonts."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-02-16T00:00:00.000Z'

--- a/content/blog/great-tables/introduction-0.3.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.3.0/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.3.0`: So Many Style Options!'
+description: "New in Great Tables v0.3.0: control column widths, style entire tables, and use system fonts."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-02-16'

--- a/content/blog/great-tables/introduction-0.4.0/index.md
+++ b/content/blog/great-tables/introduction-0.4.0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.4.0`: Nanoplots and More'
+description: "New in Great Tables v0.4.0: nanoplots for tiny, interactive visualizations inside table cells."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-03-19T00:00:00.000Z'

--- a/content/blog/great-tables/introduction-0.4.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.4.0/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables `v0.4.0`: Nanoplots and More'
+description: "New in Great Tables v0.4.0: nanoplots for tiny, interactive visualizations inside table cells."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-03-19'

--- a/content/blog/great-tables/latex-output-tables/index.md
+++ b/content/blog/great-tables/latex-output-tables/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables: Generating LaTeX Output for PDF'
+description: "Create publication-ready PDF tables by exporting Great Tables to LaTeX."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-11-13T00:00:00.000Z'

--- a/content/blog/great-tables/latex-output-tables/index.qmd
+++ b/content/blog/great-tables/latex-output-tables/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables: Generating LaTeX Output for PDF'
+description: "Create publication-ready PDF tables by exporting Great Tables to LaTeX."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-11-13'

--- a/content/blog/great-tables/locbody-mask/index.md
+++ b/content/blog/great-tables/locbody-mask/index.md
@@ -1,5 +1,7 @@
 ---
 title: Style Table Body with `mask=` in `loc.body()`
+description: "Style table cells conditionally using Polars expressions with loc.body(mask=)."
+auto-description: true
 people:
   - Jerry Wu
 date: '2025-01-24T00:00:00.000Z'

--- a/content/blog/great-tables/locbody-mask/index.qmd
+++ b/content/blog/great-tables/locbody-mask/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Style Table Body with `mask=` in `loc.body()`
+description: "Style table cells conditionally using Polars expressions with loc.body(mask=)."
+auto-description: true
 people:
   - Jerry Wu
 date: '2025-01-24'

--- a/content/blog/great-tables/marimo-and-great-tables/index.md
+++ b/content/blog/great-tables/marimo-and-great-tables/index.md
@@ -1,5 +1,7 @@
 ---
 title: Great Tables + marimo = Interactive Tables
+description: "Make your Great Tables interactive with marimo's reactive widgets."
+auto-description: true
 date: '2025-06-24T00:00:00.000Z'
 people:
   - Rich Iannone

--- a/content/blog/great-tables/marimo-and-great-tables/index.qmd
+++ b/content/blog/great-tables/marimo-and-great-tables/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Great Tables + marimo = Interactive Tables
+description: "Make your Great Tables interactive with marimo's reactive widgets."
+auto-description: true
 date: '2025-06-24'
 people:
   - Rich Iannone

--- a/content/blog/great-tables/open-transit-tools/index.md
+++ b/content/blog/great-tables/open-transit-tools/index.md
@@ -1,5 +1,7 @@
 ---
 title: Contributing to Public Transit Data Analysis and Tooling
+description: "Working on transit data? Let's collaborate on open source tools and standards."
+auto-description: true
 date: '2024-12-19T00:00:00.000Z'
 people:
   - Michael Chow

--- a/content/blog/great-tables/open-transit-tools/index.qmd
+++ b/content/blog/great-tables/open-transit-tools/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Contributing to Public Transit Data Analysis and Tooling
+description: "Working on transit data? Let's collaborate on open source tools and standards."
+auto-description: true
 date: '2024-12-19'
 people:
   - Michael Chow

--- a/content/blog/great-tables/plots-in-tables/index.md
+++ b/content/blog/great-tables/plots-in-tables/index.md
@@ -1,5 +1,7 @@
 ---
 title: Adding Plots to Great Tables
+description: "Add sparklines and small charts to your Great Tables using svg.py, HTML, or plotnine."
+auto-description: true
 people:
   - Jules Walzer-Goldfeld
   - Michael Chow

--- a/content/blog/great-tables/plots-in-tables/index.qmd
+++ b/content/blog/great-tables/plots-in-tables/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Adding Plots to Great Tables
+description: "Add sparklines and small charts to your Great Tables using svg.py, HTML, or plotnine."
+auto-description: true
 people:
   - Jules Walzer-Goldfeld
   - Michael Chow

--- a/content/blog/great-tables/pointblank-intro/index.md
+++ b/content/blog/great-tables/pointblank-intro/index.md
@@ -1,5 +1,7 @@
 ---
 title: How We Used Great Tables to Supercharge Reporting in Pointblank
+description: "See how Great Tables powers Pointblank's beautiful, shareable validation reports."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-02-11T00:00:00.000Z'

--- a/content/blog/great-tables/pointblank-intro/index.qmd
+++ b/content/blog/great-tables/pointblank-intro/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: How We Used Great Tables to Supercharge Reporting in Pointblank
+description: "See how Great Tables powers Pointblank's beautiful, shareable validation reports."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-02-11'

--- a/content/blog/great-tables/polars-dot-style/index.md
+++ b/content/blog/great-tables/polars-dot-style/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables: Becoming the Polars `.style` Property'
+description: "How Great Tables became Polars' DataFrame.style—a look at open source collaboration."
+auto-description: true
 people:
   - Michael Chow
 date: '2025-04-16T00:00:00.000Z'

--- a/content/blog/great-tables/polars-dot-style/index.qmd
+++ b/content/blog/great-tables/polars-dot-style/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables: Becoming the Polars `.style` Property'
+description: "How Great Tables became Polars' DataFrame.style—a look at open source collaboration."
+auto-description: true
 people:
   - Michael Chow
 date: '2025-04-16'

--- a/content/blog/great-tables/polars-styling/index.md
+++ b/content/blog/great-tables/polars-styling/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables: The Polars DataFrame Styler of Your Dreams'
+description: "Style Polars DataFrames for presentation using Great Tables and Polars expressions."
+auto-description: true
 people:
   - Michael Chow
 date: '2024-01-08T00:00:00.000Z'

--- a/content/blog/great-tables/polars-styling/index.qmd
+++ b/content/blog/great-tables/polars-styling/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'Great Tables: The Polars DataFrame Styler of Your Dreams'
+description: "Style Polars DataFrames for presentation using Great Tables and Polars expressions."
+auto-description: true
 people:
   - Michael Chow
 date: '2024-01-08'

--- a/content/blog/great-tables/pycon-2024-great-tables-are-possible/index.md
+++ b/content/blog/great-tables/pycon-2024-great-tables-are-possible/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'PyCon 2024: Making Beautiful, Publication Quality Tables is Possible in 2024'
+description: "Watch our PyCon 2024 talk on building publication-quality tables with Great Tables."
+auto-description: true
 date: '2024-05-16T00:00:00.000Z'
 people:
   - Michael Chow

--- a/content/blog/great-tables/pycon-2024-great-tables-are-possible/index.qmd
+++ b/content/blog/great-tables/pycon-2024-great-tables-are-possible/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'PyCon 2024: Making Beautiful, Publication Quality Tables is Possible in 2024'
+description: "Watch our PyCon 2024 talk on building publication-quality tables with Great Tables."
+auto-description: true
 date: '2024-05-16'
 people:
   - Michael Chow

--- a/content/blog/great-tables/rendering-images/index.md
+++ b/content/blog/great-tables/rendering-images/index.md
@@ -1,5 +1,7 @@
 ---
 title: Rendering images anywhere in Great Tables
+description: "Add images anywhere in your Great Tables with fmt_image() and vals.fmt_image()."
+auto-description: true
 people:
   - Jerry Wu
 date: '2024-12-13T00:00:00.000Z'

--- a/content/blog/great-tables/rendering-images/index.qmd
+++ b/content/blog/great-tables/rendering-images/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Rendering images anywhere in Great Tables
+description: "Add images anywhere in your Great Tables with fmt_image() and vals.fmt_image()."
+auto-description: true
 people:
   - Jerry Wu
 date: '2024-12-13'

--- a/content/blog/great-tables/septa-timetables/index.md
+++ b/content/blog/great-tables/septa-timetables/index.md
@@ -1,5 +1,7 @@
 ---
 title: Recreating Septa Transit Timetables in Python
+description: "Learn to build complex table layouts in Great Tables: vertical text, column spanners, and zebra striping."
+auto-description: true
 people:
   - Michael Chow
   - Rich Iannone

--- a/content/blog/great-tables/septa-timetables/index.qmd
+++ b/content/blog/great-tables/septa-timetables/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Recreating Septa Transit Timetables in Python
+description: "Learn to build complex table layouts in Great Tables: vertical text, column spanners, and zebra striping."
+auto-description: true
 people:
   - Michael Chow
   - Rich Iannone

--- a/content/blog/great-tables/superbowl-squares/index.md
+++ b/content/blog/great-tables/superbowl-squares/index.md
@@ -1,5 +1,7 @@
 ---
 title: Using Polars to Win at Super Bowl Squares
+description: "Use Polars and Great Tables to analyze which Super Bowl Squares give you the best odds."
+auto-description: true
 people:
   - Michael Chow
 date: '2024-02-08T00:00:00.000Z'

--- a/content/blog/great-tables/superbowl-squares/index.qmd
+++ b/content/blog/great-tables/superbowl-squares/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Using Polars to Win at Super Bowl Squares
+description: "Use Polars and Great Tables to analyze which Super Bowl Squares give you the best odds."
+auto-description: true
 people:
   - Michael Chow
 date: '2024-02-08'

--- a/content/blog/great-tables/tables-for-scientific-publishing/index.md
+++ b/content/blog/great-tables/tables-for-scientific-publishing/index.md
@@ -1,5 +1,7 @@
 ---
 title: Great Tables for Scientific Publishing
+description: "Format scientific tables in Great Tables: unit notation, chemical formulas, and scientific notation."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-07-08T00:00:00.000Z'

--- a/content/blog/great-tables/tables-for-scientific-publishing/index.qmd
+++ b/content/blog/great-tables/tables-for-scientific-publishing/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Great Tables for Scientific Publishing
+description: "Format scientific tables in Great Tables: unit notation, chemical formulas, and scientific notation."
+auto-description: true
 people:
   - Rich Iannone
 date: '2024-07-08'

--- a/content/blog/plotnine/2024-contest-last-call/index.md
+++ b/content/blog/plotnine/2024-contest-last-call/index.md
@@ -1,5 +1,7 @@
 ---
 title: ' 2024 Plotnine Contest - Last Call'
+description: "Final call for the 2024 Plotnine Contest—submit your best visualizations by July 26."
+auto-description: true
 date: '2024-07-22'
 categories:
   - Visualization

--- a/content/blog/plotnine/2024-contest-last-call/index.qmd
+++ b/content/blog/plotnine/2024-contest-last-call/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: ' 2024 Plotnine Contest - Last Call'
+description: "Final call for the 2024 Plotnine Contest—submit your best visualizations by July 26."
+auto-description: true
 date: '2024-07-22'
 categories:
   - Visualization

--- a/content/blog/plotnine/about-plotnine/index.md
+++ b/content/blog/plotnine/about-plotnine/index.md
@@ -1,5 +1,7 @@
 ---
 title: About Plotnine
+description: "plotnine: a grammar of graphics implementation for Python built on matplotlib and pandas."
+auto-description: true
 date: '2017-04-22'
 ported_from: plotnine
 port_status: in-progress

--- a/content/blog/plotnine/about-plotnine/index.qmd
+++ b/content/blog/plotnine/about-plotnine/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: About Plotnine
+description: "plotnine: a grammar of graphics implementation for Python built on matplotlib and pandas."
+auto-description: true
 date: '2017-04-22'
 ported_from: plotnine
 port_status: in-progress

--- a/content/blog/plotnine/version-0.14.0/index.md
+++ b/content/blog/plotnine/version-0.14.0/index.md
@@ -1,5 +1,7 @@
 ---
 title: Version 0.14.0
+description: "Plotnine v0.14.0: requires Python 3.10+, removes print() for rendering, and improves IDE support for scales."
+auto-description: true
 date: '2024-11-07'
 categories:
   - Visualization

--- a/content/blog/plotnine/version-0.14.0/index.qmd
+++ b/content/blog/plotnine/version-0.14.0/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Version 0.14.0
+description: "Plotnine v0.14.0: requires Python 3.10+, removes print() for rendering, and improves IDE support for scales."
+auto-description: true
 date: '2024-11-07'
 categories:
   - Visualization

--- a/content/blog/pointblank/all-about-actions/index.md
+++ b/content/blog/pointblank/all-about-actions/index.md
@@ -1,5 +1,7 @@
 ---
 title: Level Up Your Data Validation with `Actions` and `FinalActions`
+description: "Automate responses to bad data with Pointblank's Actions and FinalActions."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-05-02T00:00:00.000Z'

--- a/content/blog/pointblank/all-about-actions/index.qmd
+++ b/content/blog/pointblank/all-about-actions/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Level Up Your Data Validation with `Actions` and `FinalActions`
+description: "Automate responses to bad data with Pointblank's Actions and FinalActions."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-05-02'

--- a/content/blog/pointblank/intro-pointblank/index.md
+++ b/content/blog/pointblank/intro-pointblank/index.md
@@ -1,5 +1,7 @@
 ---
 title: Introducing Pointblank
+description: "Get started with Pointblank for data validation using Polars, Pandas, or DuckDB."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-04-04T00:00:00.000Z'

--- a/content/blog/pointblank/intro-pointblank/index.qmd
+++ b/content/blog/pointblank/intro-pointblank/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Introducing Pointblank
+description: "Get started with Pointblank for data validation using Polars, Pandas, or DuckDB."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-04-04'

--- a/content/blog/pointblank/lets-workshop-together/index.md
+++ b/content/blog/pointblank/lets-workshop-together/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'C''mon C''mon: Let''s Do a Pointblank Workshop!'
+description: "Want a free Pointblank workshop for your data team? Here's how to set one up."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-06-03T00:00:00.000Z'

--- a/content/blog/pointblank/lets-workshop-together/index.qmd
+++ b/content/blog/pointblank/lets-workshop-together/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: 'C''mon C''mon: Let''s Do a Pointblank Workshop!'
+description: "Want a free Pointblank workshop for your data team? Here's how to set one up."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-06-03'

--- a/content/blog/pointblank/overhauled-user-guide/index.md
+++ b/content/blog/pointblank/overhauled-user-guide/index.md
@@ -1,5 +1,7 @@
 ---
 title: Overhauling Pointblank's User Guide
+description: "Pointblank's revamped user guide: spiral learning, clearer examples, and full API coverage."
+auto-description: true
 people:
   - Rich Iannone
   - Michael Chow

--- a/content/blog/pointblank/overhauled-user-guide/index.qmd
+++ b/content/blog/pointblank/overhauled-user-guide/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Overhauling Pointblank's User Guide
+description: "Pointblank's revamped user guide: spiral learning, clearer examples, and full API coverage."
+auto-description: true
 people:
   - Rich Iannone
   - Michael Chow

--- a/content/blog/pointblank/validation-libs-2025/index.md
+++ b/content/blog/pointblank/validation-libs-2025/index.md
@@ -1,5 +1,7 @@
 ---
 title: Data Validation Libraries for Polars (2025 Edition)
+description: "Choosing a data validation library for Polars? We compare Pandera, Patito, Pointblank, Validoopsie, and Dataframely."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-06-04T00:00:00.000Z'

--- a/content/blog/pointblank/validation-libs-2025/index.qmd
+++ b/content/blog/pointblank/validation-libs-2025/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Data Validation Libraries for Polars (2025 Edition)
+description: "Choosing a data validation library for Polars? We compare Pandera, Patito, Pointblank, Validoopsie, and Dataframely."
+auto-description: true
 people:
   - Rich Iannone
 date: '2025-06-04'

--- a/content/blog/quarto/2023-12-07-quarto-dashboards-demo/index.md
+++ b/content/blog/quarto/2023-12-07-quarto-dashboards-demo/index.md
@@ -1,5 +1,7 @@
 ---
 title: Quarto Dashboards Demonstration
+description: "Video demo of Quarto v1.4's new dashboard feature with Charles Teague."
+auto-description: true
 subtitle: A brief tour of how to build a dashboard in Quarto v1.4.
 categories:
   - Publishing

--- a/content/blog/quarto/2023-12-07-quarto-dashboards-demo/index.qmd
+++ b/content/blog/quarto/2023-12-07-quarto-dashboards-demo/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Quarto Dashboards Demonstration
+description: "Video demo of Quarto v1.4's new dashboard feature with Charles Teague."
+auto-description: true
 subtitle: A brief tour of how to build a dashboard in Quarto v1.4.
 categories:
   - Publishing

--- a/content/blog/rstudio/2012-05-24-nyc-meetup-r-markdown/index.md
+++ b/content/blog/rstudio/2012-05-24-nyc-meetup-r-markdown/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'NYC Meetup: What''s Next for R Markdown'
+description: "Join us June 5th in NYC for a meetup on R Markdown with Yihui Xie and Jeff Horner."
+auto-description: true
 people:
   - RStudio Team
 date: '2012-05-24'

--- a/content/blog/rstudio/2012-05-25-mathjax-syntax-change/index.md
+++ b/content/blog/rstudio/2012-05-25-mathjax-syntax-change/index.md
@@ -1,5 +1,7 @@
 ---
 title: MathJax Syntax Change
+description: "R Markdown MathJax syntax changes: equations now use $latex ...$ to avoid parsing ambiguities."
+auto-description: true
 people:
   - RStudio Team
 date: '2012-05-25'

--- a/content/blog/rstudio/2012-06-04-announcing-rpubs/index.md
+++ b/content/blog/rstudio/2012-06-04-announcing-rpubs/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Announcing RPubs: A New Web Publishing Service for R'
+description: "Announcing RPubs: a free service to publish R Markdown documents to the web directly from RStudio."
+auto-description: true
 people:
   - RStudio Team
 date: '2012-06-04'

--- a/content/blog/rstudio/2012-08-20-welcome-hadley-winston-and-garrett/index.md
+++ b/content/blog/rstudio/2012-08-20-welcome-hadley-winston-and-garrett/index.md
@@ -1,5 +1,7 @@
 ---
 title: Welcome Hadley, Winston, and Garrett!
+description: "Hadley Wickham, Winston Chang, and Garrett Grolemund join RStudio to expand tools and education."
+auto-description: true
 people:
   - RStudio Team
 date: '2012-08-20'

--- a/content/blog/rstudio/2012-09-07-ggplot2-0-9-2/index.md
+++ b/content/blog/rstudio/2012-09-07-ggplot2-0-9-2/index.md
@@ -1,5 +1,7 @@
 ---
 title: ggplot2 0.9.2 has been released!
+description: "ggplot2 0.9.2 overhauls the theming system: opts() becomes theme(), theme_*() becomes element_*()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2012-09-07'

--- a/content/blog/rstudio/2012-09-16-devtools-0-8/index.md
+++ b/content/blog/rstudio/2012-09-16-devtools-0-8/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'New version of devtools: 0.8'
+description: "devtools 0.8 rewrites load_all() for better namespace simulation and adds support for C/C++ code and GitHub PRs."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2012-09-16'

--- a/content/blog/rstudio/2012-10-01-where-in-the-world/index.md
+++ b/content/blog/rstudio/2012-10-01-where-in-the-world/index.md
@@ -1,5 +1,7 @@
 ---
 title: Where in the world is R and RStudio
+description: "Maps visualizing where RStudio is downloaded around the world and across the US, based on web logs."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2012-10-01'

--- a/content/blog/rstudio/2012-10-08-lubridate-1-2-0-now-on-cran/index.md
+++ b/content/blog/rstudio/2012-10-08-lubridate-1-2-0-now-on-cran/index.md
@@ -1,5 +1,7 @@
 ---
 title: lubridate 1.2.0 now on CRAN
+description: "lubridate 1.2.0 is 50x faster at parsing dates, adds stamp() for custom formatting, and %m+% for safe month math."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2012-10-08'

--- a/content/blog/rstudio/2012-10-14-httr-0-2/index.md
+++ b/content/blog/rstudio/2012-10-14-httr-0-2/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'New version of httr: 0.2'
+description: "httr 0.2: an easier way to work with web APIs, with HTTP verbs, OAuth 1.0/2.0, and automatic cookie handling."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2012-10-14'

--- a/content/blog/rstudio/2012-11-08-introducing-shiny/index.md
+++ b/content/blog/rstudio/2012-11-08-introducing-shiny/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Introducing Shiny: Easy web applications in R'
+description: "Introducing Shiny: a new R package that makes it simple to build interactive web applications."
+auto-description: true
 people:
   - Joe Cheng
 date: '2012-11-08'

--- a/content/blog/rstudio/2012-12-04-shiny-update/index.md
+++ b/content/blog/rstudio/2012-12-04-shiny-update/index.md
@@ -1,5 +1,7 @@
 ---
 title: An update on Shiny
+description: "Shiny 0.2.3 adds file downloads; plus a preview of the upcoming free, open-source Shiny Server."
+auto-description: true
 people:
   - Joe Cheng
 date: '2012-12-04'

--- a/content/blog/rstudio/2012-12-06-ggplot2-plyr-release/index.md
+++ b/content/blog/rstudio/2012-12-06-ggplot2-plyr-release/index.md
@@ -1,5 +1,7 @@
 ---
 title: ggplot2 0.9.3 and plyr 1.8 have been released!
+description: "ggplot2 0.9.3 fixes bugs and adds stat warnings; plyr 1.8 brings sequential summarise() and .paropts."
+auto-description: true
 people:
   - Winston Chang
 date: '2012-12-06'

--- a/content/blog/rstudio/2013-01-22-shiny-server-now-available/index.md
+++ b/content/blog/rstudio/2013-01-22-shiny-server-now-available/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny Server now available
+description: "Shiny Server public beta: host multiple Shiny apps on Linux and share them over the web."
+auto-description: true
 people:
   - Joe Cheng
 date: '2013-01-22'

--- a/content/blog/rstudio/2013-01-23-devtools-1-0/index.md
+++ b/content/blog/rstudio/2013-01-23-devtools-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: Version 1.0 of devtools released!
+description: "devtools 1.0 adds S4 and Rcpp support plus much better Rtools detection on Windows."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2013-01-23'

--- a/content/blog/rstudio/2013-01-25-shiny-0-3-0-released-2/index.md
+++ b/content/blog/rstudio/2013-01-25-shiny-0-3-0-released-2/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 0.3.0 released
+description: "Shiny 0.3.0 improves reactive scheduling efficiency and adds runGitHub() for running apps from GitHub."
+auto-description: true
 people:
   - Winston Chang
 date: '2013-01-25'

--- a/content/blog/rstudio/2013-02-22-shiny-0-4-0-now-available/index.md
+++ b/content/blog/rstudio/2013-02-22-shiny-0-4-0-now-available/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 0.4.0 now available
+description: "Shiny 0.4.0 simplifies the reactive API and suspends invisible outputs to reduce server load."
+auto-description: true
 people:
   - Winston Chang
 date: '2013-02-22'

--- a/content/blog/rstudio/2013-04-17-devtools-1-2/index.md
+++ b/content/blog/rstudio/2013-04-17-devtools-1-2/index.md
@@ -1,5 +1,7 @@
 ---
 title: Version 1.2 of devtools released
+description: "devtools 1.2 speeds up installation, supports R 3.0 vignettes, and adds sha verification for source_url()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2013-04-17'

--- a/content/blog/rstudio/2013-06-10-rstudio-cran-mirror/index.md
+++ b/content/blog/rstudio/2013-06-10-rstudio-cran-mirror/index.md
@@ -1,5 +1,7 @@
 ---
 title: The RStudio CRAN mirror
+description: "The RStudio CRAN mirror uses CloudFront for fast global downloads, plus anonymized log data is now public."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2013-06-10'

--- a/content/blog/rstudio/2013-11-14-announcing-packrat/index.md
+++ b/content/blog/rstudio/2013-11-14-announcing-packrat/index.md
@@ -1,5 +1,7 @@
 ---
 title: Announcing Packrat
+description: "Packrat: a new tool for reproducible package management that keeps dependencies private to each project."
+auto-description: true
 people:
   - Jonathan McPherson
 date: '2013-11-14'

--- a/content/blog/rstudio/2013-11-15-shiny-0-8-0-released/index.md
+++ b/content/blog/rstudio/2013-11-15-shiny-0-8-0-released/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 0.8.0 released; Yihui Xie joins RStudio
+description: "Shiny 0.8.0 adds DataTables support and visual debugging tools. Also: Yihui Xie joins RStudio!"
+auto-description: true
 people:
   - Joe Cheng
 date: '2013-11-15'

--- a/content/blog/rstudio/2013-11-27-devtools-1-4/index.md
+++ b/content/blog/rstudio/2013-11-27-devtools-1-4/index.md
@@ -1,5 +1,7 @@
 ---
 title: devtools 1.4 now available
+description: "devtools 1.4 adds automated vignette building and a simpler install_github() syntax."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2013-11-27'

--- a/content/blog/rstudio/2013-12-03-shiny-server-0-4/index.md
+++ b/content/blog/rstudio/2013-12-03-shiny-server-0-4/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny Server 0.4
+description: "Shiny Server 0.4 brings pre-built installers for Ubuntu and RedHat, plus a beta of Shiny Server Pro."
+auto-description: true
 people:
   - RStudio Team
 date: '2013-12-03'

--- a/content/blog/rstudio/2013-12-09-roxygen2-3-0-0/index.md
+++ b/content/blog/rstudio/2013-12-09-roxygen2-3-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: roxygen2 3.0.0
+description: "roxygen2 3.0.0 adds seamless S4 and RC class documentation, smarter S3 handling, and safer roxygenise()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2013-12-09'

--- a/content/blog/rstudio/2014-01-17-introducing-dplyr/index.md
+++ b/content/blog/rstudio/2014-01-17-introducing-dplyr/index.md
@@ -1,5 +1,7 @@
 ---
 title: Introducing dplyr
+description: "dplyr: a new package for fast data manipulation with a consistent API that works on local data frames and remote databases."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-01-17'

--- a/content/blog/rstudio/2014-01-30-dplyr-0-1-1/index.md
+++ b/content/blog/rstudio/2014-01-30-dplyr-0-1-1/index.md
@@ -1,5 +1,7 @@
 ---
 title: dplyr 0.1.1
+description: "dplyr 0.1.1 fixes crash bugs, adds sort argument to tally(), and renames explain_tbl() to explain()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-01-30'

--- a/content/blog/rstudio/2014-01-30-roxygen2-3-1-0/index.md
+++ b/content/blog/rstudio/2014-01-30-roxygen2-3-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: roxygen2 3.1.0
+description: "roxygen2 3.1.0 automatically documents reference class methods from docstrings."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-01-30'

--- a/content/blog/rstudio/2014-02-25-dplyr-0-1-2/index.md
+++ b/content/blog/rstudio/2014-02-25-dplyr-0-1-2/index.md
@@ -1,5 +1,7 @@
 ---
 title: dplyr 0.1.2
+description: "dplyr 0.1.2 improves select() with starts_with(), ends_with(), contains(), and named arguments for renaming."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-02-25'

--- a/content/blog/rstudio/2014-02-25-testthat-0-8/index.md
+++ b/content/blog/rstudio/2014-02-25-testthat-0-8/index.md
@@ -1,5 +1,7 @@
 ---
 title: testthat 0.8 (and 0.8.1)
+description: "testthat 0.8 moves tests to tests/testthat/, adds line numbers in errors, and four new expectations."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-02-25'

--- a/content/blog/rstudio/2014-03-16-dplyr-0-1-3/index.md
+++ b/content/blog/rstudio/2014-03-16-dplyr-0-1-3/index.md
@@ -1,5 +1,7 @@
 ---
 title: dplyr 0.1.3
+description: "dplyr 0.1.3 fixes Rcpp compatibility and several bugs that caused R crashes."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-03-16'

--- a/content/blog/rstudio/2014-03-21-httr-0-3/index.md
+++ b/content/blog/rstudio/2014-03-21-httr-0-3/index.md
@@ -1,5 +1,7 @@
 ---
 title: httr 0.3
+description: "httr 0.3 overhauls OAuth with caching and improved authentication. Query web APIs easily from R."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-03-21'

--- a/content/blog/rstudio/2014-03-27-shiny-website-and-0-9/index.md
+++ b/content/blog/rstudio/2014-03-27-shiny-website-and-0-9/index.md
@@ -1,5 +1,7 @@
 ---
 title: New Shiny website launched; Shiny 0.9 released
+description: "Shiny Dev Center launches at shiny.rstudio.com. Shiny 0.9 adds grid layouts, navbar pages, selectize inputs, and showcase mode."
+auto-description: true
 people:
   - Joe Cheng
 date: '2014-03-27'

--- a/content/blog/rstudio/2014-04-08-devtools-1-5/index.md
+++ b/content/blog/rstudio/2014-04-08-devtools-1-5/index.md
@@ -1,5 +1,7 @@
 ---
 title: devtools 1.5
+description: "devtools 1.5 adds add_test_infrastructure(), add_travis(), add_rstudio_project() and safer install_github()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-04-08'

--- a/content/blog/rstudio/2014-05-07-new-shiny-article-style-your-apps-with-css/index.md
+++ b/content/blog/rstudio/2014-05-07-new-shiny-article-style-your-apps-with-css/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'New Shiny article: Style your apps with CSS'
+description: "New article: customize your Shiny app's appearance using CSS files and inline styles."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2014-05-07'

--- a/content/blog/rstudio/2014-05-09-reshape2-1-4/index.md
+++ b/content/blog/rstudio/2014-05-09-reshape2-1-4/index.md
@@ -1,5 +1,7 @@
 ---
 title: reshape2 1.4; Kevin Ushey joins Rstudio
+description: "reshape2 1.4 gets a C++ melt() for 10x speedup. Also: Kevin Ushey joins RStudio."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-05-09'

--- a/content/blog/rstudio/2014-05-19-roxygen2-4-0-1/index.md
+++ b/content/blog/rstudio/2014-05-19-roxygen2-4-0-1/index.md
@@ -1,5 +1,7 @@
 ---
 title: roxygen2 4.0.1
+description: "roxygen2 4.0.1 adds strict parsing with line numbers in errors, new vignettes, and safe file management."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-05-19'

--- a/content/blog/rstudio/2014-05-21-dplyr-0-2/index.md
+++ b/content/blog/rstudio/2014-05-21-dplyr-0-2/index.md
@@ -1,5 +1,7 @@
 ---
 title: dplyr 0.2
+description: "dplyr 0.2 imports %>% from magrittr, overhauls do() for list-columns, and adds sample_n(), summarise_each(), glimpse()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-05-21'

--- a/content/blog/rstudio/2014-05-28-comment-sections-and-help-instructions-at-the-shiny-dev-center/index.md
+++ b/content/blog/rstudio/2014-05-28-comment-sections-and-help-instructions-at-the-shiny-dev-center/index.md
@@ -1,5 +1,7 @@
 ---
 title: Comment sections and help instructions at the Shiny Dev Center
+description: "Shiny Dev Center adds Disqus comments on all articles and a new guide on getting help with Shiny."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2014-05-28'

--- a/content/blog/rstudio/2014-06-18-r-markdown-v2/index.md
+++ b/content/blog/rstudio/2014-06-18-r-markdown-v2/index.md
@@ -1,5 +1,7 @@
 ---
 title: R Markdown v2
+description: "R Markdown v2: Pandoc-powered output to PDF, Word, HTML, and slides. Citations, tables, footnotes, and custom templates."
+auto-description: true
 people:
   - Yihui Xie
 date: '2014-06-18'

--- a/content/blog/rstudio/2014-06-19-interactive-documents-an-incredibly-easy-way-to-use-shiny/index.md
+++ b/content/blog/rstudio/2014-06-19-interactive-documents-an-incredibly-easy-way-to-use-shiny/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Interactive documents: An incredibly easy way to use Shiny'
+description: "Interactive documents: embed Shiny widgets in R Markdown for live, interactive reports—no separate server.R/ui.R needed."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2014-06-19'

--- a/content/blog/rstudio/2014-06-20-shiny-0-10/index.md
+++ b/content/blog/rstudio/2014-06-20-shiny-0-10/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 0.10
+description: "Shiny 0.10 adds interactive document support, flowLayout/splitLayout, validate/need for errors, and server-side selectize."
+auto-description: true
 people:
   - Joe Cheng
 date: '2014-06-20'

--- a/content/blog/rstudio/2014-06-23-introducing-ggvis/index.md
+++ b/content/blog/rstudio/2014-06-23-introducing-ggvis/index.md
@@ -1,5 +1,7 @@
 ---
 title: Introducing ggvis
+description: "Introducing ggvis: grammar of graphics meets interactivity. Create reactive, browser-rendered plots with Shiny integration."
+auto-description: true
 people:
   - Winston Chang
 date: '2014-06-23'

--- a/content/blog/rstudio/2014-06-30-shiny-cheat-sheet/index.md
+++ b/content/blog/rstudio/2014-06-30-shiny-cheat-sheet/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny cheat sheet
+description: "New Shiny cheat sheet: quick reference for app structure, reactive foundations, layouts, and deployment."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2014-06-30'

--- a/content/blog/rstudio/2014-07-21-master-interactive-documents-at-the-shiny-dev-center/index.md
+++ b/content/blog/rstudio/2014-07-21-master-interactive-documents-at-the-shiny-dev-center/index.md
@@ -1,5 +1,7 @@
 ---
 title: Master interactive documents at the Shiny Dev Center
+description: "New Shiny Dev Center articles: create interactive documents and slideshows by embedding Shiny in R Markdown."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2014-07-21'

--- a/content/blog/rstudio/2014-07-22-announcing-packrat-v0-4/index.md
+++ b/content/blog/rstudio/2014-07-22-announcing-packrat-v0-4/index.md
@@ -1,5 +1,7 @@
 ---
 title: Announcing Packrat v0.4
+description: "Packrat 0.4 adds automatic snapshots, bundle/unbundle for sharing, on/off mode, and RStudio IDE integration."
+auto-description: true
 people:
   - Kevin Ushey
 date: '2014-07-22'

--- a/content/blog/rstudio/2014-07-22-introducing-tidyr/index.md
+++ b/content/blog/rstudio/2014-07-22-introducing-tidyr/index.md
@@ -1,5 +1,7 @@
 ---
 title: Introducing tidyr
+description: "Introducing tidyr: reshape messy data with gather() (wide to long), separate() (split columns), and spread() (long to wide)."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-07-22'

--- a/content/blog/rstudio/2014-07-23-new-data-packages/index.md
+++ b/content/blog/rstudio/2014-07-23-new-data-packages/index.md
@@ -1,5 +1,7 @@
 ---
 title: New data packages
+description: "Four new data packages: babynames, fueleconomy, nasaweather, and nycflights13—large datasets for learning data analysis."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-07-23'

--- a/content/blog/rstudio/2014-07-31-httr-0-4/index.md
+++ b/content/blog/rstudio/2014-07-31-httr-0-4/index.md
@@ -1,5 +1,7 @@
 ---
 title: httr 0.4
+description: "httr 0.4 adds quick start and API package vignettes, headers()/cookies() extractors, encode argument, and progress bars."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-07-31'

--- a/content/blog/rstudio/2014-08-01-shiny-0-10-1/index.md
+++ b/content/blog/rstudio/2014-08-01-shiny-0-10-1/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 0.10.1
+description: "Shiny 0.10.1 adds full Unicode support on Windows, 'user/repo' syntax for runGitHub(), and inline output options."
+auto-description: true
 people:
   - Yihui Xie
 date: '2014-08-01'

--- a/content/blog/rstudio/2014-08-01-the-r-markdown-cheat-sheet/index.md
+++ b/content/blog/rstudio/2014-08-01-the-r-markdown-cheat-sheet/index.md
@@ -1,5 +1,7 @@
 ---
 title: The R Markdown Cheat Sheet
+description: "New R Markdown cheat sheet: render reports to PDF, HTML, or Word, embed R code, and create interactive documents."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2014-08-01'

--- a/content/blog/rstudio/2014-09-03-httr-0-5/index.md
+++ b/content/blog/rstudio/2014-09-03-httr-0-5/index.md
@@ -1,5 +1,7 @@
 ---
 title: httr 0.5
+description: "httr 0.5 adds write_disk() to save response bodies directly to disk, plus preliminary HTTP caching support."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-09-03'

--- a/content/blog/rstudio/2014-09-05-packrat-on-cran/index.md
+++ b/content/blog/rstudio/2014-09-05-packrat-on-cran/index.md
@@ -1,5 +1,7 @@
 ---
 title: Packrat on CRAN
+description: "Packrat 0.4.1 hits CRAN with local repository support, experimental package caching, and Windows improvements."
+auto-description: true
 people:
   - Kevin Ushey
 date: '2014-09-05'

--- a/content/blog/rstudio/2014-09-08-track-how-visitors-use-your-shiny-app-with-google-analytics/index.md
+++ b/content/blog/rstudio/2014-09-08-track-how-visitors-use-your-shiny-app-with-google-analytics/index.md
@@ -1,5 +1,7 @@
 ---
 title: Track how visitors use your Shiny app with Google Analytics
+description: "New article: track visitors and usage patterns in your Shiny apps using Google Analytics and jQuery."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2014-09-08'

--- a/content/blog/rstudio/2014-09-23-testthat-0-9/index.md
+++ b/content/blog/rstudio/2014-09-23-testthat-0-9/index.md
@@ -1,5 +1,7 @@
 ---
 title: testthat 0.9
+description: "testthat 0.9 adds skip() and skip_on_cran(), describe() for BDD-style tests, with_mock() for mocking, and reference comparisons."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-09-23'

--- a/content/blog/rstudio/2014-10-02-devtools-1-6/index.md
+++ b/content/blog/rstudio/2014-10-02-devtools-1-6/index.md
@@ -1,5 +1,7 @@
 ---
 title: devtools 1.6
+description: "devtools 1.6 improves install_github(), adds session_info(), and introduces use_data(), use_testthat(), use_travis() helpers."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-10-02'

--- a/content/blog/rstudio/2014-10-02-shiny-0-10-2/index.md
+++ b/content/blog/rstudio/2014-10-02-shiny-0-10-2/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 0.10.2
+description: "Shiny 0.10.2 adds single-file apps (app.R), progress bars, IE 8/9 file uploads, and upgrades DataTables to 1.10."
+auto-description: true
 people:
   - Yihui Xie
 date: '2014-10-02'

--- a/content/blog/rstudio/2014-10-13-dplyr-0-3-2/index.md
+++ b/content/blog/rstudio/2014-10-13-dplyr-0-3-2/index.md
@@ -1,5 +1,7 @@
 ---
 title: dplyr 0.3
+description: "dplyr 0.3 adds distinct(), slice(), rename(), transmute(), count(), data_frame(), flexible joins, and set operations."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-10-13'

--- a/content/blog/rstudio/2014-10-13-ggvis-0-4/index.md
+++ b/content/blog/rstudio/2014-10-13-ggvis-0-4/index.md
@@ -1,5 +1,7 @@
 ---
 title: ggvis 0.4
+description: "ggvis 0.4 adds layer_boxplots(), better error handling, and more reliable interactive graphics with dynamic data."
+auto-description: true
 people:
   - Winston Chang
 date: '2014-10-13'

--- a/content/blog/rstudio/2014-10-25-rsqlite-1-0-0/index.md
+++ b/content/blog/rstudio/2014-10-25-rsqlite-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: RSQLite 1.0.0
+description: "RSQLite 1.0.0 cleans up the API, adds initExtension() for useful functions, and improves transaction handling."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-10-25'

--- a/content/blog/rstudio/2014-11-06-introduction-to-data-science-with-r-video-workshop/index.md
+++ b/content/blog/rstudio/2014-11-06-introduction-to-data-science-with-r-video-workshop/index.md
@@ -1,5 +1,7 @@
 ---
 title: Introduction to Data Science with R video workshop
+description: "New 8-hour video course from RStudio and O'Reilly covering R programming, data manipulation, visualization, and modeling."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2014-11-06'

--- a/content/blog/rstudio/2014-11-24-rvest-easy-web-scraping-with-r/index.md
+++ b/content/blog/rstudio/2014-11-24-rvest-easy-web-scraping-with-r/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'rvest: easy web scraping with R'
+description: "Introducing rvest: scrape web data with CSS selectors or XPath, extract text/tables, and navigate sites with sessions."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-11-24'

--- a/content/blog/rstudio/2014-12-01-magrittr-1-5/index.md
+++ b/content/blog/rstudio/2014-12-01-magrittr-1-5/index.md
@@ -1,5 +1,7 @@
 ---
 title: magrittr 1.5
+description: "magrittr 1.5 adds functional sequences (define functions with pipes), lambda syntax with braces, and %T>%, %$%, %<>% operators."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-12-01'

--- a/content/blog/rstudio/2014-12-08-tidyr-0-2-0/index.md
+++ b/content/blog/rstudio/2014-12-08-tidyr-0-2-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: tidyr 0.2.0 (and reshape2 1.4.1)
+description: "tidyr 0.2.0 adds expand() for filling missing combinations, unnest() for list-columns, and better separate() control."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-12-08'

--- a/content/blog/rstudio/2014-12-14-httr-0-6-0/index.md
+++ b/content/blog/rstudio/2014-12-14-httr-0-6-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: httr 0.6.0
+description: "httr 0.6.0 adds handle_reset(), streaming with write_stream(), custom HTTP verbs, and Google OAuth2 service accounts."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2014-12-14'

--- a/content/blog/rstudio/2014-12-18-htmlwidgets-javascript-data-visualization-for-r/index.md
+++ b/content/blog/rstudio/2014-12-18-htmlwidgets-javascript-data-visualization-for-r/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'htmlwidgets: JavaScript data visualization for R'
+description: "Introducing htmlwidgets: bring JavaScript visualization libraries to R. Works in console, R Markdown, and Shiny."
+auto-description: true
 people:
   - RStudio Team
 date: '2014-12-18'

--- a/content/blog/rstudio/2015-01-09-dplyr-0-4-0/index.md
+++ b/content/blog/rstudio/2015-01-09-dplyr-0-4-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: dplyr 0.4.0
+description: "dplyr 0.4.0 adds full SQL-style joins, bind_rows/bind_cols, data_frame(), list-columns, and improved printing."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-01-09'

--- a/content/blog/rstudio/2015-01-09-ggplot2-updates/index.md
+++ b/content/blog/rstudio/2015-01-09-ggplot2-updates/index.md
@@ -1,5 +1,7 @@
 ---
 title: ggplot2 updates
+description: "ggplot2 hits 1.0.0—a mature, stable release. Second edition of the ggplot2 book is in progress."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-01-09'

--- a/content/blog/rstudio/2015-01-09-rmysql-0-1-0/index.md
+++ b/content/blog/rstudio/2015-01-09-rmysql-0-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: RMySQL 0.10.0
+description: "RMySQL 0.10.0 adds CRAN binaries for Windows/Mac, transaction support, and DBI 0.3 compatibility."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-01-09'

--- a/content/blog/rstudio/2015-01-23-shiny-0-11-themes-and-dashboard/index.md
+++ b/content/blog/rstudio/2015-01-23-shiny-0-11-themes-and-dashboard/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 0.11, themes, and dashboard
+description: "Shiny 0.11 migrates to Bootstrap 3, adds improved sliders, passwordInput(), observeEvent(), plus new shinythemes and shinydashboard packages."
+auto-description: true
 people:
   - Winston Chang
 date: '2015-01-23'

--- a/content/blog/rstudio/2015-02-11-epoch-rmysql/index.md
+++ b/content/blog/rstudio/2015-02-11-epoch-rmysql/index.md
@@ -1,5 +1,7 @@
 ---
 title: Epoch.com sponsors RMySQL development
+description: "Epoch.com sponsors RMySQL development, enabling improved build systems and CRAN binaries for all platforms."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-02-11'

--- a/content/blog/rstudio/2015-03-04-haven-0-1-0/index.md
+++ b/content/blog/rstudio/2015-03-04-haven-0-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: haven 0.1.0
+description: "haven reads SAS, SPSS, and Stata files into R, including SAS7BDAT and Stata 13 formats, with labelled variable support."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-03-04'

--- a/content/blog/rstudio/2015-03-12-package-development-cheatsheet-plus-chinese-translations/index.md
+++ b/content/blog/rstudio/2015-03-12-package-development-cheatsheet-plus-chinese-translations/index.md
@@ -1,5 +1,7 @@
 ---
 title: Package Development cheatsheet, plus Chinese translations
+description: "New devtools cheatsheet for building R packages: structure, DESCRIPTION, roxygen docs, tests, and vignettes—plus Chinese translations."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2015-03-12'

--- a/content/blog/rstudio/2015-03-30-data-visualization-cheatsheet-plus-spanish-translations/index.md
+++ b/content/blog/rstudio/2015-03-30-data-visualization-cheatsheet-plus-spanish-translations/index.md
@@ -1,5 +1,7 @@
 ---
 title: Data Visualization cheatsheet, plus Spanish translations
+description: "New ggplot2 cheatsheet covering geoms, stats, scales, facets, and themes—plus Spanish translations of other cheatsheets."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2015-03-30'

--- a/content/blog/rstudio/2015-04-07-design-patterns-for-action-buttons/index.md
+++ b/content/blog/rstudio/2015-04-07-design-patterns-for-action-buttons/index.md
@@ -1,5 +1,7 @@
 ---
 title: Design patterns for action buttons
+description: "New Shiny article: five design patterns for action buttons using observeEvent() and eventReactive()."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2015-04-07'

--- a/content/blog/rstudio/2015-04-09-readr-0-1-0/index.md
+++ b/content/blog/rstudio/2015-04-09-readr-0-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: readr 0.1.0
+description: "Introducing readr: read CSV, TSV, and fixed-width files 10x faster than base R, with automatic type detection and no stringsAsFactors."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-04-09'

--- a/content/blog/rstudio/2015-04-14-interactive-time-series-with-dygraphs/index.md
+++ b/content/blog/rstudio/2015-04-14-interactive-time-series-with-dygraphs/index.md
@@ -1,5 +1,7 @@
 ---
 title: Interactive time series with dygraphs
+description: "dygraphs brings interactive time series charts to R: pan, zoom, highlight, annotate, and embed in R Markdown or Shiny."
+auto-description: true
 people:
   - RStudio Team
 date: '2015-04-14'

--- a/content/blog/rstudio/2015-04-15-readxl-0-1-0/index.md
+++ b/content/blog/rstudio/2015-04-15-readxl-0-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: Get data out of excel and into R with readxl
+description: "readxl reads both .xls and .xlsx files with no external dependencies. Fast, handles dates, and auto-drops blank columns."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-04-15'

--- a/content/blog/rstudio/2015-04-21-xml2/index.md
+++ b/content/blog/rstudio/2015-04-21-xml2/index.md
@@ -1,5 +1,7 @@
 ---
 title: Parse and process XML (and HTML) with xml2
+description: "xml2 wraps libxml2 for easy XML/HTML parsing in R: navigate trees, extract nodes with XPath, and handle namespaces."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-04-21'

--- a/content/blog/rstudio/2015-05-05-stringr-1-0-0/index.md
+++ b/content/blog/rstudio/2015-05-05-stringr-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: stringr 1.0.0
+description: "stringr 1.0.0 is now powered by stringi for faster performance and better unicode. Adds str_subset(), boundary(), and locale-aware sorting."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-05-05'

--- a/content/blog/rstudio/2015-05-11-devtools-1-9-0/index.md
+++ b/content/blog/rstudio/2015-05-11-devtools-1-9-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: devtools 1.8.0
+description: "devtools 1.8 adds use_git(), use_test(), dr_devtools(), and better dependency management with package_deps()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-05-11'

--- a/content/blog/rstudio/2015-05-28-sparkr-preview-by-vincent-warmerdam/index.md
+++ b/content/blog/rstudio/2015-05-28-sparkr-preview-by-vincent-warmerdam/index.md
@@ -1,5 +1,7 @@
 ---
 title: SparkR preview by Vincent Warmerdam
+description: "Guest tutorial: Get started with SparkR for distributed computing—install locally, run map/reduce operations, and deploy on AWS."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2015-05-28'

--- a/content/blog/rstudio/2015-05-29-testthat-0-10-0/index.md
+++ b/content/blog/rstudio/2015-05-29-testthat-0-10-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: testthat 0.10.0
+description: "testthat 0.10.0 improves R CMD check output, adds skip_if_not_installed(), and soft-deprecates expect_that() style."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-05-29'

--- a/content/blog/rstudio/2015-06-16-shiny-0-12-interactive-plots-with-ggplot2/index.md
+++ b/content/blog/rstudio/2015-06-16-shiny-0-12-interactive-plots-with-ggplot2/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Shiny 0.12: Interactive Plots with ggplot2'
+description: "Shiny 0.12 adds interactive plots for base graphics and ggplot2: capture mouse clicks, hovers, and brushes to select points."
+auto-description: true
 people:
   - Joe Cheng
 date: '2015-06-16'

--- a/content/blog/rstudio/2015-06-22-new-shiny-cheat-sheet-and-video-tutorial/index.md
+++ b/content/blog/rstudio/2015-06-22-new-shiny-cheat-sheet-and-video-tutorial/index.md
@@ -1,5 +1,7 @@
 ---
 title: New Shiny cheat sheet and video tutorial
+description: "New free Shiny video tutorial (2.5 hours) and updated cheat sheet covering app architecture, reactivity, inputs, layouts, and CSS."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2015-06-22'

--- a/content/blog/rstudio/2015-06-24-d3heatmap/index.md
+++ b/content/blog/rstudio/2015-06-24-d3heatmap/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'd3heatmap: Interactive heat maps'
+description: "d3heatmap creates interactive heat maps with D3.js: zoom by dragging, highlight rows/columns on click, hover to see values."
+auto-description: true
 people:
   - Joe Cheng
 date: '2015-06-24'

--- a/content/blog/rstudio/2015-06-24-dt-an-r-interface-to-the-datatables-library/index.md
+++ b/content/blog/rstudio/2015-06-24-dt-an-r-interface-to-the-datatables-library/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'DT: An R interface to the DataTables library'
+description: "DT brings DataTables to R: sortable, filterable, paginated HTML tables with column formatting and Shiny integration."
+auto-description: true
 people:
   - Yihui Xie
 date: '2015-06-24'

--- a/content/blog/rstudio/2015-06-24-leaflet-interactive-web-maps-with-r/index.md
+++ b/content/blog/rstudio/2015-06-24-leaflet-interactive-web-maps-with-r/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Leaflet: Interactive web maps with R'
+description: "Create interactive web maps in R with leaflet: markers, polygons, popups, GeoJSON support, and seamless Shiny integration."
+auto-description: true
 people:
   - Yihui Xie
 date: '2015-06-24'

--- a/content/blog/rstudio/2015-06-30-accelerating-r-rstudio-and-the-new-r-consortium/index.md
+++ b/content/blog/rstudio/2015-06-30-accelerating-r-rstudio-and-the-new-r-consortium/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Accelerating R: RStudio and the new R Consortium'
+description: "RStudio joins the new R Consortium alongside Microsoft, Google, and Oracle to fund and inspire R's future development."
+auto-description: true
 people:
   - RStudio Team
 date: '2015-06-30'

--- a/content/blog/rstudio/2015-07-15-article-spotlight-persistent-data-storage-in-shiny-apps/index.md
+++ b/content/blog/rstudio/2015-07-15-article-spotlight-persistent-data-storage-in-shiny-apps/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Article Spotlight: Persistent data storage in Shiny apps'
+description: "Article spotlight: Dean Attali explains how to save Shiny app data to local files, databases, and cloud storage for persistence."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2015-07-15'

--- a/content/blog/rstudio/2015-07-22-new-r-markdown-articles-section-plus-rmd-to-docx-super-powers/index.md
+++ b/content/blog/rstudio/2015-07-22-new-r-markdown-articles-section-plus-rmd-to-docx-super-powers/index.md
@@ -1,5 +1,7 @@
 ---
 title: New R Markdown articles section, plus .Rmd to .docx super powers!
+description: "New R Markdown articles section launched with tips for Word output: styles, margins, tables, and bibliographies."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2015-07-22'

--- a/content/blog/rstudio/2015-09-04-dplyr-0-4-3/index.md
+++ b/content/blog/rstudio/2015-09-04-dplyr-0-4-3/index.md
@@ -1,5 +1,7 @@
 ---
 title: dplyr 0.4.3
+description: "dplyr 0.4.3 fixes mutate() crashes, improves non-ASCII column support, shows column types when printing, and adds bind_rows(.id)."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-09-04'

--- a/content/blog/rstudio/2015-09-13-devtools-1-9-1/index.md
+++ b/content/blog/rstudio/2015-09-13-devtools-1-9-1/index.md
@@ -1,5 +1,7 @@
 ---
 title: devtools 1.9.1
+description: "devtools 1.9.1 adds remote dependencies via DESCRIPTION's Remotes field, improved GitHub integration, and better revdep_check()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-09-13'

--- a/content/blog/rstudio/2015-09-13-tidyr-0-3-0/index.md
+++ b/content/blog/rstudio/2015-09-13-tidyr-0-3-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: tidyr 0.3.0
+description: "tidyr 0.3.0 adds fill() for carrying forward values, replace_na(), complete() for missing combinations, and unnest() for list columns."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-09-13'

--- a/content/blog/rstudio/2015-09-24-rvest-0-3-0/index.md
+++ b/content/blog/rstudio/2015-09-24-rvest-0-3-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: rvest 0.3.0
+description: "rvest 0.3.0 switches to xml2 for better performance and no memory leaks. html() becomes read_html(), html_tag() becomes html_name()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-09-24'

--- a/content/blog/rstudio/2015-09-29-purrr-0-1-0/index.md
+++ b/content/blog/rstudio/2015-09-29-purrr-0-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: purrr 0.1.0
+description: "Introducing purrr: functional programming tools for R with map functions, formula shortcuts for anonymous functions, and list manipulation."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-09-29'

--- a/content/blog/rstudio/2015-10-15-testthat-0-11-0/index.md
+++ b/content/blog/rstudio/2015-10-15-testthat-0-11-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: testthat 0.11.0
+description: "testthat 0.11.0 adds expect_silent() for checking no output/warnings, skip_on_os() and skip_on_appveyor(), plus random encouragement."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-10-15'

--- a/content/blog/rstudio/2015-10-28-readr-0-2-0/index.md
+++ b/content/blog/rstudio/2015-10-28-readr-0-2-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: readr 0.2.0
+description: "readr 0.2.0 adds locales for international data (encodings, date formats, decimal marks), comment support, and CSV/TSV writers."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-10-28'

--- a/content/blog/rstudio/2015-10-29-roxygen2-5-0-0/index.md
+++ b/content/blog/rstudio/2015-10-29-roxygen2-5-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: roxygen2 5.0.0
+description: "roxygen2 5.0.0 adds RoxygenNote for version tracking, easier package documentation, and support for documenting re-exported functions."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-10-29'

--- a/content/blog/rstudio/2015-10-29-shiny-developer-conference-stanford-university-january-2016/index.md
+++ b/content/blog/rstudio/2015-10-29-shiny-developer-conference-stanford-university-january-2016/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny Developer Conference | Stanford University | January 2016
+description: "Announcing the first Shiny Developer Conference at Stanford, January 2016, for developers ready to build performant, robust Shiny apps."
+auto-description: true
 people:
   - Joe Cheng
 date: '2015-10-29'

--- a/content/blog/rstudio/2015-12-10-svglite-1-0-0/index.md
+++ b/content/blog/rstudio/2015-12-10-svglite-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: svglite 1.0.0
+description: "svglite produces compact, web-optimized SVG graphics from R, with smaller file sizes and faster rendering than base R's svg() device."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-12-10'

--- a/content/blog/rstudio/2015-12-21-ggplot2-2-0-0/index.md
+++ b/content/blog/rstudio/2015-12-21-ggplot2-2-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: ggplot 2.0.0
+description: "ggplot2 2.0.0: official extension mechanism, new geoms (geom_count, geom_curve, geom_label), appearance tweaks, and facet labels."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2015-12-21'

--- a/content/blog/rstudio/2016-01-06-purrr-0-2-0/index.md
+++ b/content/blog/rstudio/2016-01-06-purrr-0-2-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: purrr 0.2.0
+description: "purrr 0.2.0 adds type-stable map functions (map_lgl/int/dbl/chr), flatten variants, and safely() for error handling."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-01-06'

--- a/content/blog/rstudio/2016-01-15-rcppparallel-getting-r-and-c-to-work-some-more-in-parallel/index.md
+++ b/content/blog/rstudio/2016-01-15-rcppparallel-getting-r-and-c-to-work-some-more-in-parallel/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'RcppParallel: Getting R and C++ to work (some more) in parallel'
+description: "RcppParallel provides portable parallel C++ algorithms using Intel TBB or TinyThread, achieving 200-300x speedups."
+auto-description: true
 people:
   - RStudio Team
 date: '2016-01-15'

--- a/content/blog/rstudio/2016-01-20-shiny-0-13-0/index.md
+++ b/content/blog/rstudio/2016-01-20-shiny-0-13-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 0.13.0
+description: "Shiny 0.13.0 introduces Gadgets for interactive tools, HTML templates, modules for managing complexity, and stack traces."
+auto-description: true
 people:
   - Winston Chang
 date: '2016-01-20'

--- a/content/blog/rstudio/2016-02-02-devtools-1-10-0/index.md
+++ b/content/blog/rstudio/2016-02-02-devtools-1-10-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: Devtools 1.10.0
+description: "devtools 1.10.0 improves Windows RTools detection, adds use_news_md() and use_mit_license(), with lazy GitHub installs."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-02-02'

--- a/content/blog/rstudio/2016-02-02-httr-1-1-0/index.md
+++ b/content/blog/rstudio/2016-02-02-httr-1-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: httr 1.1.0 (and 1.0.0)
+description: "httr 1.0.0 switches from RCurl to curl for reliability; 1.1.0 improves error messages and OAuth support."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-02-02'

--- a/content/blog/rstudio/2016-02-02-memoise-1-0-0/index.md
+++ b/content/blog/rstudio/2016-02-02-memoise-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: memoise 1.0.0
+description: "memoise 1.0.0 caches function results with better printing, argument forwarding, and time-based invalidation."
+auto-description: true
 people:
   - Jim Hester
 date: '2016-02-02'

--- a/content/blog/rstudio/2016-02-02-tidyr-0-4-0/index.md
+++ b/content/blog/rstudio/2016-02-02-tidyr-0-4-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: tidyr 0.4.0
+description: "tidyr 0.4.0 introduces nested data frames with nest()/unnest() and complete() for making implicit missing values explicit."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-02-02'

--- a/content/blog/rstudio/2016-03-03-ggplot2-2-1-0/index.md
+++ b/content/blog/rstudio/2016-03-03-ggplot2-2-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: ggplot2 2.1.0
+description: "ggplot2 2.1.0 fixes bugs from 2.0.0 with better histogram binning, consistent argument ordering, and alpha behavior."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-03-03'

--- a/content/blog/rstudio/2016-03-09-r-on-travis-ci/index.md
+++ b/content/blog/rstudio/2016-03-09-r-on-travis-ci/index.md
@@ -1,5 +1,7 @@
 ---
 title: R on Travis-CI
+description: "Improved R support on Travis-CI with container-based infrastructure, package caching, and multiple R versions."
+auto-description: true
 people:
   - Jim Hester
 date: '2016-03-09'

--- a/content/blog/rstudio/2016-03-21-r-markdown-custom-formats/index.md
+++ b/content/blog/rstudio/2016-03-21-r-markdown-custom-formats/index.md
@@ -1,5 +1,7 @@
 ---
 title: R Markdown Custom Formats
+description: "Overview of custom R Markdown formats (tufte, rticles, rmdformats) and how to create your own output formats."
+auto-description: true
 people:
   - RStudio Team
 date: '2016-03-21'

--- a/content/blog/rstudio/2016-03-21-rmarkdown-v0-9-5/index.md
+++ b/content/blog/rstudio/2016-03-21-rmarkdown-v0-9-5/index.md
@@ -1,5 +1,7 @@
 ---
 title: R Markdown v0.9.5
+description: "R Markdown 0.9.5 adds floating table of contents, code folding, tabbed sections, and five new HTML themes."
+auto-description: true
 people:
   - RStudio Team
 date: '2016-03-21'

--- a/content/blog/rstudio/2016-03-24-tibble-1-0-0/index.md
+++ b/content/blog/rstudio/2016-03-24-tibble-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: tibble 1.0.0
+description: "Introducing the tibble package: modern data frames with better printing, stricter subsetting, and no string-to-factor conversion."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-03-24'

--- a/content/blog/rstudio/2016-03-29-feather/index.md
+++ b/content/blog/rstudio/2016-03-29-feather/index.md
@@ -1,6 +1,8 @@
 ---
 title: 'Feather: A Fast On-Disk Format for Data Frames for R and Python, powered by
   Apache Arrow'
+description: "Introducing Feather: a fast binary file format for data frames that works in both R and Python, built on Apache Arrow."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-03-29'

--- a/content/blog/rstudio/2016-04-29-testthat-1-0-0/index.md
+++ b/content/blog/rstudio/2016-04-29-testthat-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: testthat 1.0.0
+description: "testthat 1.0.0 adds pipe support, new expectations, consistent side-effect testing, and C++ unit testing with Catch."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-04-29'

--- a/content/blog/rstudio/2016-05-05-shinydevcon-videos-now-available/index.md
+++ b/content/blog/rstudio/2016-05-05-shinydevcon-videos-now-available/index.md
@@ -1,5 +1,7 @@
 ---
 title: ShinyDevCon videos now available
+description: "Videos from the 2016 Shiny Developer Conference covering reactive programming, modules, gadgets, and debugging."
+auto-description: true
 people:
   - Joe Cheng
 date: '2016-05-05'

--- a/content/blog/rstudio/2016-05-06-shiny-javascript-tutorials/index.md
+++ b/content/blog/rstudio/2016-05-06-shiny-javascript-tutorials/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny JavaScript Tutorials
+description: "New tutorial series on creating custom JavaScript widgets for Shiny using libraries like c3.js, d3.js, and intro.js."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2016-05-06'

--- a/content/blog/rstudio/2016-05-17-flexdashboard-easy-interactive-dashboards-for-r/index.md
+++ b/content/blog/rstudio/2016-05-17-flexdashboard-easy-interactive-dashboards-for-r/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'flexdashboard: Easy interactive dashboards for R'
+description: "Introducing flexdashboard: create interactive dashboards with R Markdown, htmlwidgets, and optional Shiny components."
+auto-description: true
 people:
   - RStudio Team
 date: '2016-05-17'

--- a/content/blog/rstudio/2016-06-13-tidyr-0-5-0/index.md
+++ b/content/blog/rstudio/2016-06-13-tidyr-0-5-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: tidyr 0.5.0
+description: "tidyr 0.5.0 adds separate_rows() for delimiter-separated values, plus sep arguments for spread() and unnest()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-06-13'

--- a/content/blog/rstudio/2016-06-27-dplyr-0-5-0/index.md
+++ b/content/blog/rstudio/2016-06-27-dplyr-0-5-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: dplyr 0.5.0
+description: "dplyr 0.5.0 adds coalesce(), if_else(), case_when(), recode(), and the summarise_all/at/if family of functions."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-06-27'

--- a/content/blog/rstudio/2016-07-05-httr-1-2-0/index.md
+++ b/content/blog/rstudio/2016-07-05-httr-1-2-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: httr 1.2.0
+description: "httr 1.2.0 adds RETRY() for unreliable APIs with exponential backoff, and fixes POST redirect issues."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-07-05'

--- a/content/blog/rstudio/2016-07-05-tibble-1-1/index.md
+++ b/content/blog/rstudio/2016-07-05-tibble-1-1/index.md
@@ -1,5 +1,7 @@
 ---
 title: tibble 1.1
+description: "tibble 1.1 introduces tibble(), as_tibble(), and is_tibble() naming, plus safer column extraction with warnings."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-07-05'

--- a/content/blog/rstudio/2016-07-05-xml2-1-0-0/index.md
+++ b/content/blog/rstudio/2016-07-05-xml2-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: xml2 1.0.0
+description: "xml2 1.0.0 adds XML creation and modification, xml_find_first() for ragged data, and easier namespace handling."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-07-05'

--- a/content/blog/rstudio/2016-08-05-readr-1-0-0/index.md
+++ b/content/blog/rstudio/2016-08-05-readr-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: readr 1.0.0
+description: "readr 1.0.0 improves column guessing with printed specs, adds better date/time parsers and low-level file readers."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-08-05'

--- a/content/blog/rstudio/2016-08-09-a-new-version-of-dt-0-2-on-cran/index.md
+++ b/content/blog/rstudio/2016-08-09-a-new-version-of-dt-0-2-on-cran/index.md
@@ -1,5 +1,7 @@
 ---
 title: A New Version of DT (0.2) on CRAN
+description: "DT 0.2 adds the Buttons extension, row/column/cell selection, and functions to modify tables without rebuilding."
+auto-description: true
 people:
   - Yihui Xie
 date: '2016-08-09'

--- a/content/blog/rstudio/2016-08-15-tidyr-0-6-0/index.md
+++ b/content/blog/rstudio/2016-08-15-tidyr-0-6-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: tidyr 0.6.0
+description: "tidyr 0.6.0 adds drop_na() to remove rows containing missing values in selected or all columns."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-08-15'

--- a/content/blog/rstudio/2016-08-24-stringr-1-1-0/index.md
+++ b/content/blog/rstudio/2016-08-24-stringr-1-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: stringr 1.1.0
+description: "stringr 1.1.0 adds practice datasets (fruit, words, sentences), boundary() in more functions, and str_view() for regex."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-08-24'

--- a/content/blog/rstudio/2016-08-29-tibble-1-2-0/index.md
+++ b/content/blog/rstudio/2016-08-29-tibble-1-2-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: tibble 1.2.0
+description: "tibble 1.2.0 adds add_column(), improves add_row() with position control, and renames frame_data() to tribble()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-08-29'

--- a/content/blog/rstudio/2016-08-31-forcats-0-1-0/index.md
+++ b/content/blog/rstudio/2016-08-31-forcats-0-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'forcats 0.1.0 '
+description: "Introducing forcats: tools for working with factors including fct_recode(), fct_lump(), and fct_reorder()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-08-31'

--- a/content/blog/rstudio/2016-09-12-shiny-0-14/index.md
+++ b/content/blog/rstudio/2016-09-12-shiny-0-14/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 0.14
+description: "Shiny 0.14 adds bookmarkable state, notifications, modal dialogs, insertUI/removeUI, and database connection docs."
+auto-description: true
 people:
   - Winston Chang
 date: '2016-09-12'

--- a/content/blog/rstudio/2016-09-15-lubridate-1-6-0/index.md
+++ b/content/blog/rstudio/2016-09-15-lubridate-1-6-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: lubridate 1.6.0
+description: "lubridate 1.6.0 adds flexible period/duration parsing from strings and date rounding with unit multipliers."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-09-15'

--- a/content/blog/rstudio/2016-09-15-tidyverse-1-0-0/index.md
+++ b/content/blog/rstudio/2016-09-15-tidyverse-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: tidyverse 1.0.0
+description: "The tidyverse package installs and loads core tidyverse packages (ggplot2, dplyr, tidyr, readr, purrr, tibble) in one command."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-09-15'

--- a/content/blog/rstudio/2016-09-22-shiny-server-1-4-6/index.md
+++ b/content/blog/rstudio/2016-09-22-shiny-server-1-4-6/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny Server (Pro) 1.4.6
+description: "Shiny Server 1.4.6 includes bug fixes and security mitigations; Pro users on SSL/TLS should upgrade for OpenSSL patches."
+auto-description: true
 people:
   - Joe Cheng
 date: '2016-09-22'

--- a/content/blog/rstudio/2016-09-27-sparklyr-r-interface-for-apache-spark/index.md
+++ b/content/blog/rstudio/2016-09-27-sparklyr-r-interface-for-apache-spark/index.md
@@ -1,5 +1,7 @@
 ---
 title: sparklyr — R interface for Apache Spark
+description: "Introducing sparklyr: use dplyr syntax to manipulate Spark data and run distributed machine learning from R."
+auto-description: true
 people:
   - RStudio Team
 date: '2016-09-27'

--- a/content/blog/rstudio/2016-09-30-ggplot2-2-2-0-coming-soon/index.md
+++ b/content/blog/rstudio/2016-09-30-ggplot2-2-2-0-coming-soon/index.md
@@ -1,5 +1,7 @@
 ---
 title: ggplot2 2.2.0 coming soon!
+description: "Preview of ggplot2 2.2.0 with subtitles, captions, facet rewrites, theme improvements, and better stacking."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-09-30'

--- a/content/blog/rstudio/2016-10-04-haven-1-0-0/index.md
+++ b/content/blog/rstudio/2016-10-04-haven-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: haven 1.0.0
+description: "haven 1.0.0 reads and writes SAS, SPSS, and Stata files with improved missing value and date/time support."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-10-04'

--- a/content/blog/rstudio/2016-10-13-shinythemes-1-1-1/index.md
+++ b/content/blog/rstudio/2016-10-13-shinythemes-1-1-1/index.md
@@ -1,5 +1,7 @@
 ---
 title: shinythemes 1.1.1
+description: "shinythemes 1.1.1 adds new Bootstrap themes from bootswatch.com and a live theme selector for Shiny apps."
+auto-description: true
 people:
   - Winston Chang
 date: '2016-10-13'

--- a/content/blog/rstudio/2016-11-14-ggplot2-2-2-0/index.md
+++ b/content/blog/rstudio/2016-11-14-ggplot2-2-2-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: ggplot2 2.2.0
+description: "ggplot2 2.2.0 adds subtitles and captions, rewrites the facet system, improves theming, and fixes stacking order."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-11-14'

--- a/content/blog/rstudio/2016-11-14-svglite-1-2-0/index.md
+++ b/content/blog/rstudio/2016-11-14-svglite-1-2-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: svglite 1.2.0
+description: "svglite 1.2.0 improves font handling with system_fonts and user_fonts arguments, plus text scaling fixes."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2016-11-14'

--- a/content/blog/rstudio/2016-12-02-announcing-bookdown/index.md
+++ b/content/blog/rstudio/2016-12-02-announcing-bookdown/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Announcing bookdown: Authoring Books and Technical Documents with R Markdown'
+description: "bookdown extends R Markdown for writing books with cross-references, citations, and multiple output formats."
+auto-description: true
 people:
   - Yihui Xie
 date: '2016-12-02'

--- a/content/blog/rstudio/2017-01-24-sparklyr-0-5/index.md
+++ b/content/blog/rstudio/2017-01-24-sparklyr-0-5/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'sparklyr 0.5: Livy and dplyr improvements'
+description: "sparklyr 0.5 extends dplyr with do() and n_distinct(), adds experimental Livy support for remote Spark connections."
+auto-description: true
 people:
   - Javier Luraschi
 date: '2017-01-24'

--- a/content/blog/rstudio/2017-01-24-xml-1-1-1/index.md
+++ b/content/blog/rstudio/2017-01-24-xml-1-1-1/index.md
@@ -1,5 +1,7 @@
 ---
 title: xml2 1.1.1
+description: "xml2 1.1.1 adds tools for creating and modifying XML, improved list conversion, and XML validation support."
+auto-description: true
 people:
   - Jim Hester
 date: '2017-01-24'

--- a/content/blog/rstudio/2017-02-01-roxygen2-6-0-0/index.md
+++ b/content/blog/rstudio/2017-02-01-roxygen2-6-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: roxygen2 6.0.0
+description: "roxygen2 6.0.0 introduces markdown syntax for documentation and improved inheritance with @inherit tags."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2017-02-01'

--- a/content/blog/rstudio/2017-02-22-leaflet-1-1-0/index.md
+++ b/content/blog/rstudio/2017-02-22-leaflet-1-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: leaflet 1.1.0
+description: "leaflet 1.1.0 adds text labels, shape highlighting, awesome-markers, sf support, custom projections, and viridis palettes."
+auto-description: true
 people:
   - Joe Cheng
 date: '2017-02-22'

--- a/content/blog/rstudio/2017-04-05-shiny-1-0-1/index.md
+++ b/content/blog/rstudio/2017-04-05-shiny-1-0-1/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 1.0.1
+description: "Shiny 1.0.1 adds reactiveVal() for single reactive values and HTML content in radio buttons and checkboxes."
+auto-description: true
 people:
   - Bárbara Borges Ribeiro
 date: '2017-04-05'

--- a/content/blog/rstudio/2017-04-12-tidyverse-updates/index.md
+++ b/content/blog/rstudio/2017-04-12-tidyverse-updates/index.md
@@ -1,5 +1,7 @@
 ---
 title: tidyverse updates
+description: "Tidyverse package updates: forcats 0.2.0, readr 1.1.0, stringr 1.2.0, and tibble 1.3.0."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2017-04-12'

--- a/content/blog/rstudio/2017-04-13-dplyr-0-6-0-coming-soon/index.md
+++ b/content/blog/rstudio/2017-04-13-dplyr-0-6-0-coming-soon/index.md
@@ -1,5 +1,7 @@
 ---
 title: dplyr 0.6.0 coming soon!
+description: "dplyr 0.6.0 preview: database changes with dbplyr, CJK encoding support, and tidy evaluation."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2017-04-13'

--- a/content/blog/rstudio/2017-04-19-readxl-1-0-0/index.md
+++ b/content/blog/rstudio/2017-04-19-readxl-1-0-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: readxl 1.0.0
+description: "readxl 1.0.0: target specific cells for reading Excel files plus new logical and list column types."
+auto-description: true
 people:
   - Jenny Bryan
 date: '2017-04-19'

--- a/content/blog/rstudio/2017-05-18-shinydashboard-0-6-0/index.md
+++ b/content/blog/rstudio/2017-05-18-shinydashboard-0-6-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: shinydashboard 0.6.0
+description: "shinydashboard 0.6.0: bookmarkable state for sidebars and new inputs for tracking collapsed state."
+auto-description: true
 people:
   - Bárbara Borges Ribeiro
 date: '2017-05-18'

--- a/content/blog/rstudio/2017-06-13-dplyr-0-7-0/index.md
+++ b/content/blog/rstudio/2017-06-13-dplyr-0-7-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: dplyr 0.7.0
+description: "dplyr 0.7.0: tidy evaluation for programming with dplyr, new datasets, and improved encoding support."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2017-06-13'

--- a/content/blog/rstudio/2017-06-26-bigrquery-0-4-0/index.md
+++ b/content/blog/rstudio/2017-06-26-bigrquery-0-4-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: bigrquery 0.4.0
+description: "bigrquery 0.4.0: query Google BigQuery with DBI and dplyr backends, now with full datetime support."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2017-06-26'

--- a/content/blog/rstudio/2017-06-27-dbplyr-1-1-0/index.md
+++ b/content/blog/rstudio/2017-06-27-dbplyr-1-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: dbplyr 1.1.0
+description: "dbplyr 1.1.0: database backends now work directly with DBI connections and feature improved SQL translation."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2017-06-27'

--- a/content/blog/rstudio/2017-07-07-introducing-learnr/index.md
+++ b/content/blog/rstudio/2017-07-07-introducing-learnr/index.md
@@ -1,5 +1,7 @@
 ---
 title: Introducing learnr
+description: "Introducing learnr: create interactive R tutorials with exercises, quizzes, and videos."
+auto-description: true
 people:
   - Garrett Grolemund
 date: '2017-07-11'

--- a/content/blog/rstudio/2017-07-13-haven-1-1-0/index.md
+++ b/content/blog/rstudio/2017-07-13-haven-1-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: haven 1.1.0
+description: "haven 1.1.0: SAS transport files, cols_only for selective reading, and bug fixes."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2017-07-13'

--- a/content/blog/rstudio/2017-07-31-sparklyr-0-6/index.md
+++ b/content/blog/rstudio/2017-07-31-sparklyr-0-6/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'sparklyr 0.6: Distributed R and external sources'
+description: "sparklyr 0.6: distributed R with spark_apply() and external data source connections."
+auto-description: true
 people:
   - Javier Luraschi
 date: '2017-07-31'

--- a/content/blog/rstudio/2017-08-15-shiny-1-0-4/index.md
+++ b/content/blog/rstudio/2017-08-15-shiny-1-0-4/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 1.0.4
+description: "Shiny 1.0.4: drag-and-drop file inputs, dynamic tab management, and onStop callbacks."
+auto-description: true
 people:
   - Winston Chang
 date: '2017-08-15'

--- a/content/blog/rstudio/2017-08-29-shiny-dev-center-gets-a-shiny-new-update/index.md
+++ b/content/blog/rstudio/2017-08-29-shiny-dev-center-gets-a-shiny-new-update/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny Dev Center gets a shiny new update
+description: "Shiny Dev Center redesigned: clearer learning paths and updated articles for Shiny developers."
+auto-description: true
 people:
   - Mine Çetinkaya-Rundel
 date: '2017-08-29'

--- a/content/blog/rstudio/2017-09-05-keras-for-r/index.md
+++ b/content/blog/rstudio/2017-09-05-keras-for-r/index.md
@@ -1,5 +1,7 @@
 ---
 title: Keras for R
+description: "Introducing Keras for R: a high-level neural networks API for fast deep learning experimentation."
+auto-description: true
 people:
   - JJ Allaire
 date: '2017-09-05'

--- a/content/blog/rstudio/2017-09-11-announcing-blogdown/index.md
+++ b/content/blog/rstudio/2017-09-11-announcing-blogdown/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Announcing blogdown: Create Websites with R Markdown'
+description: "Announcing blogdown: create static websites with R Markdown and Hugo."
+auto-description: true
 people:
   - Yihui Xie
 date: '2017-09-11'

--- a/content/blog/rstudio/2017-09-14-rstudio-community/index.md
+++ b/content/blog/rstudio/2017-09-14-rstudio-community/index.md
@@ -1,5 +1,7 @@
 ---
 title: community.rstudio.com
+description: "Announcing community.rstudio.com: a friendly forum for RStudio, tidyverse, and Shiny discussions."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2017-09-14'

--- a/content/blog/rstudio/2017-11-03-r-admins-community/index.md
+++ b/content/blog/rstudio/2017-11-03-r-admins-community/index.md
@@ -1,5 +1,7 @@
 ---
 title: R-Admins Community
+description: "Announcing the R-Admins community forum for R administrators working in production environments."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2017-11-03'

--- a/content/blog/rstudio/2017-11-17-pool-0-1-3/index.md
+++ b/content/blog/rstudio/2017-11-17-pool-0-1-3/index.md
@@ -1,5 +1,7 @@
 ---
 title: pool package on CRAN
+description: "pool package: connection pooling for databases in Shiny apps with automatic connection management."
+auto-description: true
 people:
   - Bárbara Borges Ribeiro
 date: '2017-11-17'

--- a/content/blog/rstudio/2018-01-29-sparklyr-0-7/index.md
+++ b/content/blog/rstudio/2018-01-29-sparklyr-0-7/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'sparklyr 0.7: Spark Pipelines and Machine Learning'
+description: "sparklyr 0.7: ML Pipelines API for building, tuning, and deploying machine learning workflows at scale."
+auto-description: true
 people:
   - Kevin Kuo
 date: '2018-01-29'

--- a/content/blog/rstudio/2018-03-26-reticulate-r-interface-to-python/index.md
+++ b/content/blog/rstudio/2018-03-26-reticulate-r-interface-to-python/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'reticulate: R interface to Python'
+description: "Introducing reticulate: seamless interoperability between R and Python with automatic type conversion."
+auto-description: true
 people:
   - JJ Allaire
 date: '2018-03-26'

--- a/content/blog/rstudio/2018-03-29-dt-0-4/index.md
+++ b/content/blog/rstudio/2018-03-29-dt-0-4/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'DT 0.4: Editing Tables, Smart Filtering, and More'
+description: "DT 0.4: editable tables, smart filtering, and shift-click row selection for Shiny apps."
+auto-description: true
 people:
   - Yihui Xie
 date: '2018-03-29'

--- a/content/blog/rstudio/2018-04-19-arrow-and-beyond/index.md
+++ b/content/blog/rstudio/2018-04-19-arrow-and-beyond/index.md
@@ -1,6 +1,8 @@
 ---
 title: 'Arrow and beyond: Collaborating on next generation tools for open source data
   science'
+description: "RStudio partners with Ursa Labs to build a cross-language data science runtime powered by Apache Arrow."
+auto-description: true
 people:
   - JJ Allaire
 date: '2018-04-19'

--- a/content/blog/rstudio/2018-05-14-sparklyr-0-8/index.md
+++ b/content/blog/rstudio/2018-05-14-sparklyr-0-8/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'sparklyr 0.8: Production pipelines and graphs'
+description: "sparklyr 0.8: production ML pipelines with mleap export and graph analysis with graphframes."
+auto-description: true
 people:
   - Kevin Kuo
 date: '2018-05-14'

--- a/content/blog/rstudio/2018-06-26-shiny-1-1-0/index.md
+++ b/content/blog/rstudio/2018-06-26-shiny-1-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Shiny 1.1.0: Scaling Shiny with async'
+description: "Shiny 1.1.0: async programming support via future and promises for better scalability under load."
+auto-description: true
 people:
   - Joe Cheng
 date: '2018-06-26'

--- a/content/blog/rstudio/2018-07-13-announcing-the-r-markdown-book/index.md
+++ b/content/blog/rstudio/2018-07-13-announcing-the-r-markdown-book/index.md
@@ -1,5 +1,7 @@
 ---
 title: Announcing the R Markdown Book
+description: "Announcing R Markdown: The Definitive Guide, a comprehensive book on R Markdown and its extensions."
+auto-description: true
 people:
   - Yihui Xie
 date: '2018-07-13'

--- a/content/blog/rstudio/2018-07-25-revamped-bookdown-org/index.md
+++ b/content/blog/rstudio/2018-07-25-revamped-bookdown-org/index.md
@@ -1,5 +1,7 @@
 ---
 title: The Revamped bookdown.org Website
+description: "The revamped bookdown.org website: browse, search, and contribute books written with bookdown."
+auto-description: true
 people:
   - Yihui Xie
 date: '2018-07-25'

--- a/content/blog/rstudio/2018-09-12-getting-started-with-deep-learning-in-r/index.md
+++ b/content/blog/rstudio/2018-09-12-getting-started-with-deep-learning-in-r/index.md
@@ -1,5 +1,7 @@
 ---
 title: Getting started with deep learning in R
+description: "Resources for getting started with deep learning in R using Keras and TensorFlow."
+auto-description: true
 people:
   - Sigrid Keydana
 date: '2018-09-12'

--- a/content/blog/rstudio/2018-09-19-radix-for-r-markdown/index.md
+++ b/content/blog/rstudio/2018-09-19-radix-for-r-markdown/index.md
@@ -1,5 +1,7 @@
 ---
 title: Radix for R Markdown
+description: "Introducing Radix: an R Markdown format optimized for scientific communication with flexible layouts."
+auto-description: true
 people:
   - JJ Allaire
 date: '2018-09-19'

--- a/content/blog/rstudio/2018-10-01-sparklyr-0-9/index.md
+++ b/content/blog/rstudio/2018-10-01-sparklyr-0-9/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'sparklyr 0.9: Streams and Kubernetes'
+description: "sparklyr 0.9: Spark structured streams for real-time data processing and Kubernetes cluster support."
+auto-description: true
 people:
   - Javier Luraschi
 date: '2018-10-01'

--- a/content/blog/rstudio/2018-11-13-shiny-1-2-0/index.md
+++ b/content/blog/rstudio/2018-11-13-shiny-1-2-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Shiny 1.2.0: Plot caching'
+description: "Shiny 1.2.0: plot caching with renderCachedPlot for dramatically improved performance under load."
+auto-description: true
 people:
   - Joe Cheng
 date: '2018-11-13'

--- a/content/blog/rstudio/2019-02-06-rstudio-conf-2019-workshops/index.md
+++ b/content/blog/rstudio/2019-02-06-rstudio-conf-2019-workshops/index.md
@@ -1,5 +1,7 @@
 ---
 title: rstudio::conf 2019 Workshop materials now available
+description: "All 15 workshop materials from rstudio::conf 2019, covering tidyverse, Shiny, R Markdown, and machine learning."
+auto-description: true
 people:
   - Mine Çetinkaya-Rundel
 date: '2019-02-06'

--- a/content/blog/rstudio/2019-03-06-sparklyr-1-0/index.md
+++ b/content/blog/rstudio/2019-03-06-sparklyr-1-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'sparklyr 1.0: Apache Arrow, XGBoost, Broom and TFRecords'
+description: "sparklyr 1.0: Apache Arrow for faster data transfers, XGBoost models, broom integration, and TFRecords."
+auto-description: true
 people:
   - Javier Luraschi
 date: '2019-03-15'

--- a/content/blog/rstudio/2019-04-26-shiny-1-3-2/index.md
+++ b/content/blog/rstudio/2019-04-26-shiny-1-3-2/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny v1.3.2
+description: "Shiny 1.3.2: reactlog for visually debugging reactivity and faster static file serving."
+auto-description: true
 people:
   - Joe Cheng
 date: '2019-04-26'

--- a/content/blog/rstudio/2019-08-05-the-shiny-developer-series/index.md
+++ b/content/blog/rstudio/2019-08-05-the-shiny-developer-series/index.md
@@ -1,5 +1,7 @@
 ---
 title: The Shiny Developer Series
+description: "The Shiny Developer Series: video interviews with package authors and advanced Shiny techniques."
+auto-description: true
 people:
   - Curtis Kephart
 date: '2019-08-05'

--- a/content/blog/rstudio/2019-09-09-pins-track-discover-and-share-datasets/index.md
+++ b/content/blog/rstudio/2019-09-09-pins-track-discover-and-share-datasets/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'pins: Pin, Discover and Share Resources'
+description: "Introducing pins: cache remote resources locally, discover datasets, and share across teams."
+auto-description: true
 people:
   - RStudio Team
 date: '2019-09-09'

--- a/content/blog/rstudio/2019-10-15-shiny-1-4-0/index.md
+++ b/content/blog/rstudio/2019-10-15-shiny-1-4-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny 1.4.0
+description: "Shiny 1.4.0: trailing commas now work in UI functions like div() and span()."
+auto-description: true
 people:
   - Winston Chang
 date: '2019-10-15'

--- a/content/blog/rstudio/2019-11-06-renv-project-environments-for-r/index.md
+++ b/content/blog/rstudio/2019-11-06-renv-project-environments-for-r/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'renv: Project Environments for R'
+description: "Introducing renv: isolated, portable, reproducible R project environments to replace Packrat."
+auto-description: true
 people:
   - Kevin Ushey
 date: '2019-11-06'

--- a/content/blog/rstudio/2019-12-02-learnr-0-10-0/index.md
+++ b/content/blog/rstudio/2019-12-02-learnr-0-10-0/index.md
@@ -1,5 +1,7 @@
 ---
 title: learnr 0.10.0
+description: "learnr 0.10.0: new quiz question types including text boxes and drag-and-drop ranking."
+auto-description: true
 people:
   - Barret Schloerke
 date: '2019-12-02'

--- a/content/blog/rstudio/2019-12-20-reticulate-1-14/index.md
+++ b/content/blog/rstudio/2019-12-20-reticulate-1-14/index.md
@@ -1,5 +1,7 @@
 ---
 title: reticulate 1.14
+description: "reticulate 1.14: automatic Python environment configuration for R packages that use Python."
+auto-description: true
 people:
   - Kevin Ushey
 date: '2019-12-20'

--- a/content/blog/rstudio/2020-01-29-sparklyr-1-1-foundations-books-lakes-and-barriers/index.md
+++ b/content/blog/rstudio/2020-01-29-sparklyr-1-1-foundations-books-lakes-and-barriers/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'sparklyr 1.1: Foundations, Books, Lakes and Barriers'
+description: "sparklyr 1.1: Delta Lake support, Spark 3.0 preview, and barrier execution for deep learning."
+auto-description: true
 people:
   - Javier Luraschi
 date: '2020-01-29'

--- a/content/blog/rstudio/2020-04-06-gt-0-2/index.md
+++ b/content/blog/rstudio/2020-04-06-gt-0-2/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'Great Looking Tables: gt (v0.2)'
+description: "Introducing gt v0.2: a grammar of tables for creating beautiful customized display tables in R."
+auto-description: true
 people:
   - Richard Iannone
 date: '2020-04-08'

--- a/content/blog/rstudio/2020-05-04-sparklyr-1-2-foreach-spark-3-0-and-databricks-connect/index.md
+++ b/content/blog/rstudio/2020-05-04-sparklyr-1-2-foreach-spark-3-0-and-databricks-connect/index.md
@@ -1,5 +1,7 @@
 ---
 title: 'sparklyr 1.2: Foreach, Spark 3.0 and Databricks Connect'
+description: "sparklyr 1.2: foreach parallel backend, Databricks Connect support, and Spark 3.0 compatibility."
+auto-description: true
 people:
   - Yitao Li
 date: '2020-05-06'

--- a/content/blog/rstudio/2020-09-29-introducing-torch-for-R/index.md
+++ b/content/blog/rstudio/2020-09-29-introducing-torch-for-R/index.md
@@ -1,5 +1,7 @@
 ---
 title: Introducing torch for R
+description: "Announcing torch for R: use PyTorch natively in R for deep learning."
+auto-description: true
 people:
   - RStudio Team
 date: '2020-09-29'

--- a/content/blog/rstudio/2021-05-20-asa-datafest-2021/index.md
+++ b/content/blog/rstudio/2021-05-20-asa-datafest-2021/index.md
@@ -1,5 +1,7 @@
 ---
 title: ASA DataFest 2021
+description: "Recap of the 2021 ASA DataFest: 2,500+ students analyzing drug misuse survey data."
+auto-description: true
 people:
   - Mine Çetinkaya-Rundel
 date: '2021-05-20'

--- a/content/blog/rstudio/2021-07-22-three-shiny-best-practices-seen-in-the-shiny-contest/index.md
+++ b/content/blog/rstudio/2021-07-22-three-shiny-best-practices-seen-in-the-shiny-contest/index.md
@@ -1,5 +1,7 @@
 ---
 title: Top 3 Coding Best Practices from the Shiny Contest
+description: "Three coding best practices from Shiny Contest winners: modules, custom CSS, and reactive organization."
+auto-description: true
 people:
   - Nick Strayer
 date: '2021-07-22'

--- a/content/blog/shiny/shiny-at-conf-2025/index.md
+++ b/content/blog/shiny/shiny-at-conf-2025/index.md
@@ -1,5 +1,7 @@
 ---
 title: Shiny at posit::conf(2025)
+description: "Find Shiny talks and workshops at posit::conf(2025) in Atlanta."
+auto-description: true
 subtitle: Atlanta, GA (September 2025)
 people:
   - Shiny Team

--- a/content/blog/shiny/shiny-at-conf-2025/index.qmd
+++ b/content/blog/shiny/shiny-at-conf-2025/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Shiny at posit::conf(2025)
+description: "Find Shiny talks and workshops at posit::conf(2025) in Atlanta."
+auto-description: true
 subtitle: Atlanta, GA (September 2025)
 people:
   - Shiny Team

--- a/content/blog/shiny/shiny-at-scipy-2025/index.md
+++ b/content/blog/shiny/shiny-at-scipy-2025/index.md
@@ -1,5 +1,7 @@
 ---
 title: Posit at SciPy 2025
+description: "Catch up on the Shiny team's talks and tutorials from SciPy 2025."
+auto-description: true
 subtitle: Tacoma, WA (July 2025)
 people:
   - Shiny Team

--- a/content/blog/shiny/shiny-at-scipy-2025/index.qmd
+++ b/content/blog/shiny/shiny-at-scipy-2025/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Posit at SciPy 2025
+description: "Catch up on the Shiny team's talks and tutorials from SciPy 2025."
+auto-description: true
 subtitle: Tacoma, WA (July 2025)
 people:
   - Shiny Team

--- a/content/blog/tidyverse/2017/rstudio-community/index.md
+++ b/content/blog/tidyverse/2017/rstudio-community/index.md
@@ -1,5 +1,7 @@
 ---
 title: RStudio community
+description: "RStudio Community forum: a new place to ask questions about tidyverse, Shiny, and more."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2017-09-14'

--- a/content/blog/tidyverse/2019/dbplyr-1-4-0/index.Rmarkdown
+++ b/content/blog/tidyverse/2019/dbplyr-1-4-0/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: dbplyr 1.4.0
+description: "dbplyr 1.4.0: simpler SQL generation, better translations, and improved window functions."
+auto-description: true
 author:
   - Hadley Wickham
 date: '2019-04-30'

--- a/content/blog/tidyverse/2019/dbplyr-1-4-0/index.markdown
+++ b/content/blog/tidyverse/2019/dbplyr-1-4-0/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: dbplyr 1.4.0
+description: "dbplyr 1.4.0: simpler SQL generation, better translations, and improved window functions."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2019-04-30'

--- a/content/blog/tidyverse/2019/pkgdown-1-4-0/index.Rmarkdown
+++ b/content/blog/tidyverse/2019/pkgdown-1-4-0/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: pkgdown 1.4.0
+description: "pkgdown 1.4.0: deployment vs development modes for building package websites."
+auto-description: true
 author:
   - Hadley Wickham
 date: '2019-09-05'

--- a/content/blog/tidyverse/2019/pkgdown-1-4-0/index.markdown
+++ b/content/blog/tidyverse/2019/pkgdown-1-4-0/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: pkgdown 1.4.0
+description: "pkgdown 1.4.0: deployment vs development modes for building package websites."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2019-09-05'

--- a/content/blog/tidyverse/2019/testthat-2-3-0/index.markdown
+++ b/content/blog/tidyverse/2019/testthat-2-3-0/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: testthat 2.3.0
+description: "testthat 2.3.0: verify_output() for testing printed output and improved parallel testing."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2019-11-06'

--- a/content/blog/tidyverse/2019/tidyr-1-0-0/index.markdown
+++ b/content/blog/tidyverse/2019/tidyr-1-0-0/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: tidyr 1.0.0
+description: "tidyr 1.0.0: pivot_longer() and pivot_wider() replace spread() and gather()."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2019-09-13'

--- a/content/blog/tidyverse/2020/glue-strings-and-tidy-eval/index.Rmarkdown
+++ b/content/blog/tidyverse/2020/glue-strings-and-tidy-eval/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: Tidy eval now supports glue strings
+description: "Use {{ and { with glue strings in tidy eval to create dynamic column names in tidyverse verbs."
+auto-description: true
 author:
   - Lionel Henry
 date: '2020-02-11'

--- a/content/blog/tidyverse/2020/glue-strings-and-tidy-eval/index.markdown
+++ b/content/blog/tidyverse/2020/glue-strings-and-tidy-eval/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: Tidy eval now supports glue strings
+description: "Use {{ and { with glue strings in tidy eval to create dynamic column names in tidyverse verbs."
+auto-description: true
 people:
   - Lionel Henry
 date: '2020-02-11'

--- a/content/blog/tidyverse/2020/googlesheets4-0-2-0/index.Rmarkdown
+++ b/content/blog/tidyverse/2020/googlesheets4-0-2-0/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: googlesheets4 0.2.0
+description: "googlesheets4 0.2.0: create and edit Google Sheets from R, now a full replacement for the googlesheets package."
+auto-description: true
 author:
   - Jenny Bryan
 date: '2020-05-10'

--- a/content/blog/tidyverse/2020/googlesheets4-0-2-0/index.markdown
+++ b/content/blog/tidyverse/2020/googlesheets4-0-2-0/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: googlesheets4 0.2.0
+description: "googlesheets4 0.2.0: create and edit Google Sheets from R, now a full replacement for the googlesheets package."
+auto-description: true
 people:
   - Jenny Bryan
 date: '2020-05-10'

--- a/content/blog/tidyverse/2020/pkgdown-1-5-0/index.Rmarkdown
+++ b/content/blog/tidyverse/2020/pkgdown-1-5-0/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: pkgdown 1.5.0
+description: "pkgdown 1.5.0: article descriptions, better navbar control, and richer Open Graph metadata."
+auto-description: true
 author:
   - Hadley Wickham
 date: '2020-03-25'

--- a/content/blog/tidyverse/2020/pkgdown-1-5-0/index.markdown
+++ b/content/blog/tidyverse/2020/pkgdown-1-5-0/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: pkgdown 1.5.0
+description: "pkgdown 1.5.0: article descriptions, better navbar control, and richer Open Graph metadata."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2020-03-25'

--- a/content/blog/tidyverse/2020/usethis-1-6-0/index.Rmarkdown
+++ b/content/blog/tidyverse/2020/usethis-1-6-0/index.Rmarkdown
@@ -1,5 +1,7 @@
 ---
 title: usethis 1.6.0
+description: "usethis 1.6.0: GitHub Actions for CI, smoother package creation, and improved PR workflows."
+auto-description: true
 author:
   - Hadley Wickham
 date: '2020-04-11'

--- a/content/blog/tidyverse/2020/usethis-1-6-0/index.markdown
+++ b/content/blog/tidyverse/2020/usethis-1-6-0/index.markdown
@@ -1,5 +1,7 @@
 ---
 title: usethis 1.6.0
+description: "usethis 1.6.0: GitHub Actions for CI, smoother package creation, and improved PR workflows."
+auto-description: true
 people:
   - Hadley Wickham
 date: '2020-04-11'


### PR DESCRIPTION
## Summary

- Adds `description` and `auto-description: true` frontmatter to ~150 blog posts that were missing descriptions
- Descriptions are concise (~150 chars), reader-focused summaries suitable for list pages and SEO
- Posts span from May 2012 to early 2025, covering package releases, tutorials, announcements, and conference content

## Test plan

- [x] Hugo builds successfully
- [ ] Spot-check a few blog list pages to confirm descriptions render correctly