### PR TITLE
Add bio and social links for Daniel Falbel

### DIFF
--- a/content/people/daniel-falbel/_index.md
+++ b/content/people/daniel-falbel/_index.md
@@ -4,11 +4,13 @@ image: "profile.jpg"
 role: "Senior Software Engineer"
 affiliation: "Posit, PBC"
 social:
-  bluesky: ""
+  bluesky: "dfalbel.bsky.social"
   github: "dfalbel"
-  linkedin: ""
-  mastodon: ""
-  orcid: ""
-  website: ""
+  linkedin: "daniel-falbel-54b1a834"
+  mastodon: "https://fosstodon.org/@dfalbel"
+  orcid: "0009-0006-0143-2392"
+  website: "https://dfalbel.github.io/"
   youtube: ""
 ---
+
+I am a software engineer at [Posit PBC](https://posit.co/) based in Brazil. I work on open-source tools at the intersection of R and machine learning, including [torch](https://torch.mlverse.org/), [keras](https://keras3.posit.co/), and the broader [mlverse](https://github.com/mlverse) ecosystem. I also contribute to packages like [reticulate](https://rstudio.github.io/reticulate/) and other projects that bridge R and Python.


### PR DESCRIPTION
## Summary
- Add biography text to Daniel Falbel's profile page
- Add social links: Bluesky, Mastodon, LinkedIn, ORCID, and personal website