### PR TITLE
Update karan-gathani profile

### DIFF
--- a/content/people/karan-gathani/_index.md
+++ b/content/people/karan-gathani/_index.md
@@ -5,10 +5,11 @@ role: "Senior Quality Assurance Engineer"
 affiliation: "Posit, PBC"
 social:
   bluesky: ""
-  github: "kgathani"
+  github: "karangattu"
   linkedin: ""
   mastodon: ""
   orcid: ""
-  website: ""
+  website: "https://www.californianaturalistdiaries.com/"
   youtube: ""
 ---
+Karan is a Senior Quality Assurance Engineer at Posit, where he works on Shiny. He has worked with tech startups across the San Francisco Bay Area, helping them ship products efficiently without compromising on quality. In his spare time, he takes part in BioBlitzes around the Bay Area and contributes to this natural history blog.


### PR DESCRIPTION
Update Karan Gathani's profile: change GitHub handle to "karangattu", add a personal website, and append a short bio describing his role at Posit, experience with Bay Area startups, and participation in BioBlitzes and natural history blogging.