### PR TITLE
Render markdown in card/hero titles and descriptions

### DIFF
--- a/layouts/partials/item.html
+++ b/layouts/partials/item.html
@@ -57,7 +57,7 @@
 {{/* ============================================================
      TITLE
      ============================================================ */}}
-{{ $title := $page.Title }}
+{{ $title := $page.RenderString (dict "display" "inline") $page.Title }}
 
 {{/* ============================================================
      DATE (formatted using block/date_range.html for events)
@@ -77,6 +77,7 @@
      ============================================================ */}}
 {{ $description_field := $card_settings.description_field | default "description" }}
 {{ $description := index $page.Params $description_field | strings.TrimSpace | strings.TrimSuffix "." | replaceRE `[\x{1F600}-\x{1F64F}\x{1F300}-\x{1F5FF}\x{1F680}-\x{1F6FF}\x{2600}-\x{26FF}\x{2700}-\x{27BF}]` "" }}
+{{ $description = $page.RenderString (dict "display" "inline") $description }}
 
 {{/* ============================================================
      AUTHOR (linked in hero, plain text in card/tile/row since


### PR DESCRIPTION
Fixes #85

## Summary

- Post titles and descriptions containing markdown (backticks, links, etc.) were displaying as raw syntax in cards and hero blocks
- Fixes both by passing through `RenderString` with `display: "inline"` — prevents wrapping `<p>` tags while converting markdown to HTML

## Scanned for side effects

- Intra-word underscores (e.g. `if_else()`) — CommonMark doesn't treat these as emphasis, no issue
- Glob wildcards (`chat_*`) — no matching `*` on both sides, renders as literal text
- Descriptions with `[text](url)` links — these now render as `<a>` tags, which is an improvement

## Paths to check in preview

- `/blog/quarto/2024-12-12-includes-meta/` — reported post, title has backticks
- `/blog/tidyverse/dplyr-performance/` — description with backticks in hero block
- `/blog/tidyverse/2023/purrr-walk-this-way/` — title is almost entirely backtick code
- `/blog/tidyverse/2023/dplyr-1-1-0-pick-reframe-arrange/` — mixed plain + backtick title
- `/blog/great-tables/` — listing page with multiple backtick titles in cards
- `/blog/tidyverse/2020/dplyr-1-0-0-and-vctrs/` — description with a markdown link