### PR TITLE
Replace Quarto layout tables with CSS grid (fixes #133)

### DIFF
--- a/content/_extensions/layout/_extension.yml
+++ b/content/_extensions/layout/_extension.yml
@@ -1,0 +1,4 @@
+title: Layout
+contributes:
+  filters:
+    - layout.lua

--- a/content/_extensions/layout/layout.lua
+++ b/content/_extensions/layout/layout.lua
@@ -1,5 +1,7 @@
 -- layout filter for Hugo
--- Transforms layout-ncol / layout / layout-nrow divs into CSS grid HTML.
+-- Transforms multi-column divs into CSS grid HTML:
+--   1. layout-ncol / layout attributes (Quarto layout system)
+--   2. .columns / .column width="..." divs (Pandoc native columns)
 -- Uses the HTML+AST sandwich pattern so cell content (code blocks, images,
 -- markdown) is kept as Pandoc AST and rendered correctly by Goldmark.
 -- Mirrors the Tailwind classes used by layouts/shortcodes/columns.html.
@@ -85,6 +87,45 @@ local function weights_to_grid_class(weights)
   return "md:grid-cols-[" .. table.concat(parts, "_") .. "]"
 end
 
+-- Check whether a div is a .columns container (or has .column children).
+-- Returns (cells, weights) or nil if not a columns div.
+local function parse_columns_div(div)
+  -- Direct .columns class on the div
+  local is_columns = div.classes:includes("columns")
+
+  -- Or: a container whose children are .column divs
+  if not is_columns then
+    local has_column_child = false
+    for _, el in ipairs(div.content) do
+      if el.t == "Div" and el.classes:includes("column") then
+        has_column_child = true
+        break
+      end
+    end
+    if not has_column_child then return nil end
+  end
+
+  local cells = pandoc.List()
+  local weights = pandoc.List()
+
+  for _, el in ipairs(div.content) do
+    if el.t == "Div" and el.classes:includes("column") then
+      cells:insert(el.content)
+      -- Extract width="N%" → N as weight
+      local w = el.attributes["width"]
+      if w then
+        local num = w:match("^(%d+)%%?$")
+        weights:insert(num or "1")
+      else
+        weights:insert("1")
+      end
+    end
+  end
+
+  if #cells == 0 then return nil end
+  return cells, weights
+end
+
 -- Emit one grid row as a list of Pandoc blocks (HTML+AST sandwich).
 local function render_row(cells, grid_class, align_class, extra_classes)
   local blocks = pandoc.List()
@@ -110,72 +151,70 @@ function Div(div)
   local ncol   = div.attributes["layout-ncol"]
   local layout = div.attributes["layout"]
 
-  -- Only act on divs that carry a layout attribute
-  if not ncol and not layout then
-    return div
-  end
+  -- Branch 1: layout-ncol / layout attributes
+  if ncol or layout then
+    local valign = div.attributes["layout-valign"]
+    local align_class = (valign == "center") and "items-center" or "items-start"
 
-  local valign = div.attributes["layout-valign"]
-  local align_class = (valign == "center") and "items-center" or "items-start"
-
-  -- Pass through any non-layout classes on the outer div
-  -- (e.g. column-body-outset-right), but strip Quarto's own layout classes.
-  local layout_class_prefixes = {
-    "column%-", "layout%-"
-  }
-  local extra_parts = pandoc.List()
-  for _, cls in ipairs(div.classes) do
-    local skip = false
-    for _, prefix in ipairs(layout_class_prefixes) do
-      if cls:match("^" .. prefix) then skip = true; break end
+    -- Pass through any non-layout classes on the outer div
+    -- (e.g. column-body-outset-right), but strip Quarto's own layout classes.
+    local extra_parts = pandoc.List()
+    for _, cls in ipairs(div.classes) do
+      if not cls:match("^column%-") and not cls:match("^layout%-") then
+        extra_parts:insert(cls)
+      end
     end
-    if not skip then
-      extra_parts:insert(cls)
-    end
-  end
-  local extra_classes = table.concat(extra_parts, " ")
+    local extra_classes = table.concat(extra_parts, " ")
 
-  local blocks = pandoc.List()
+    local blocks = pandoc.List()
 
-  if layout then
-    -- layout="[W1,W2]" or layout="[[R1C1,R1C2],[R2C1]]"
-    local rows, is_multi = parse_layout_string(layout)
-
-    if is_multi then
-      -- Multiple rows: each row gets its own grid div.
-      -- We need to split cells across rows according to the row widths.
-      local all_cells = collect_cells(div)
-      local cell_idx = 1
-      for _, weights in ipairs(rows) do
-        local ncols_in_row = #weights
-        local row_cells = pandoc.List()
-        for _ = 1, ncols_in_row do
-          if all_cells[cell_idx] then
-            row_cells:insert(all_cells[cell_idx])
-            cell_idx = cell_idx + 1
+    if layout then
+      local rows, is_multi = parse_layout_string(layout)
+      if is_multi then
+        local all_cells = collect_cells(div)
+        local cell_idx = 1
+        for _, weights in ipairs(rows) do
+          local ncols_in_row = #weights
+          local row_cells = pandoc.List()
+          for _ = 1, ncols_in_row do
+            if all_cells[cell_idx] then
+              row_cells:insert(all_cells[cell_idx])
+              cell_idx = cell_idx + 1
+            end
           end
+          local gcls = weights_to_grid_class(weights)
+          blocks:extend(render_row(row_cells, gcls, align_class, extra_classes))
+          extra_classes = ""
         end
+      else
+        local weights = rows[1]
         local gcls = weights_to_grid_class(weights)
-        blocks:extend(render_row(row_cells, gcls, align_class, extra_classes))
-        -- Only apply extra_classes (like column-body-outset-right) to the first row
-        extra_classes = ""
+        local cells = collect_cells(div)
+        blocks:extend(render_row(cells, gcls, align_class, extra_classes))
       end
     else
-      local weights = rows[1]
-      local gcls = weights_to_grid_class(weights)
+      local n = tonumber(ncol) or 2
+      local gcls = "md:grid-cols-" .. n
       local cells = collect_cells(div)
       blocks:extend(render_row(cells, gcls, align_class, extra_classes))
     end
 
-  else
-    -- layout-ncol=N: equal-width columns
-    local weights = pandoc.List()
-    local n = tonumber(ncol) or 2
-    for _ = 1, n do weights:insert("1") end
-    local gcls = "md:grid-cols-" .. n
-    local cells = collect_cells(div)
-    blocks:extend(render_row(cells, gcls, align_class, extra_classes))
+    return blocks
   end
 
-  return blocks
+  -- Branch 2: .columns class or container with .column children
+  local col_cells, col_weights = parse_columns_div(div)
+  if col_cells then
+    -- Pass through non-column classes (e.g. column-page-inset, room)
+    local extra_parts = pandoc.List()
+    for _, cls in ipairs(div.classes) do
+      if cls ~= "columns" and not cls:match("^column$") then
+        extra_parts:insert(cls)
+      end
+    end
+    local extra_classes = table.concat(extra_parts, " ")
+
+    local gcls = weights_to_grid_class(col_weights)
+    return render_row(col_cells, gcls, "items-start", extra_classes)
+  end
 end

--- a/content/_extensions/layout/layout.lua
+++ b/content/_extensions/layout/layout.lua
@@ -1,0 +1,181 @@
+-- layout filter for Hugo
+-- Transforms layout-ncol / layout / layout-nrow divs into CSS grid HTML.
+-- Uses the HTML+AST sandwich pattern so cell content (code blocks, images,
+-- markdown) is kept as Pandoc AST and rendered correctly by Goldmark.
+-- Mirrors the Tailwind classes used by layouts/shortcodes/columns.html.
+
+-- Collect cells from a layout div.
+-- If any direct children are Div elements, each Div is one cell.
+-- Otherwise, each top-level block is one cell (common for bare image grids).
+local function collect_cells(div)
+  local cells = pandoc.List()
+  local has_divs = false
+
+  for _, el in ipairs(div.content) do
+    if el.t == "Div" then
+      has_divs = true
+      break
+    end
+  end
+
+  if has_divs then
+    for _, el in ipairs(div.content) do
+      if el.t == "Div" then
+        cells:insert(el.content)
+      end
+    end
+  else
+    for _, el in ipairs(div.content) do
+      local cell = pandoc.List()
+      cell:insert(el)
+      cells:insert(cell)
+    end
+  end
+
+  return cells
+end
+
+-- Parse a layout weight string like "[70,30]" or "[[3,1]]" into a list of
+-- weight strings, handling both single-row shorthand and explicit multi-row.
+-- Returns two values: rows (list of lists of weight strings), is_multi_row.
+local function parse_layout_string(layout)
+  -- Multi-row: "[[r1c1,r1c2],[r2c1,...]]"
+  local is_multi = layout:match("^%[%[")
+  if is_multi then
+    local rows = pandoc.List()
+    -- Extract each [...] group inside the outer [[...]]
+    for row_str in layout:gmatch("%[([^%[%]]+)%]") do
+      local weights = pandoc.List()
+      for w in row_str:gmatch("[^,]+") do
+        weights:insert(w:match("^%s*(.-)%s*$"))  -- trim
+      end
+      rows:insert(weights)
+    end
+    return rows, true
+  else
+    -- Single-row shorthand: "[70,30]"
+    local inner = layout:match("%[(.-)%]")
+    if not inner then return pandoc.List(), false end
+    local weights = pandoc.List()
+    for w in inner:gmatch("[^,]+") do
+      weights:insert(w:match("^%s*(.-)%s*$"))
+    end
+    local rows = pandoc.List()
+    rows:insert(weights)
+    return rows, false
+  end
+end
+
+-- Build the Tailwind grid-cols class for a list of weight strings.
+local function weights_to_grid_class(weights)
+  -- Check if all weights are equal (emit md:grid-cols-N for cleaner output)
+  local first = weights[1]
+  local all_equal = true
+  for _, w in ipairs(weights) do
+    if w ~= first then all_equal = false; break end
+  end
+  if all_equal then
+    return "md:grid-cols-" .. #weights
+  end
+  -- Proportional: md:grid-cols-[70fr_30fr]
+  local parts = pandoc.List()
+  for _, w in ipairs(weights) do
+    parts:insert(w .. "fr")
+  end
+  return "md:grid-cols-[" .. table.concat(parts, "_") .. "]"
+end
+
+-- Emit one grid row as a list of Pandoc blocks (HTML+AST sandwich).
+local function render_row(cells, grid_class, align_class, extra_classes)
+  local blocks = pandoc.List()
+  local classes = "grid gap-12 " .. align_class .. " mt-12 " .. grid_class
+  if extra_classes ~= "" then
+    classes = classes .. " " .. extra_classes
+  end
+  blocks:insert(pandoc.RawBlock("html", '<div class="' .. classes .. '">'))
+  for _, cell in ipairs(cells) do
+    blocks:insert(pandoc.RawBlock("html", '<div class="prose max-w-none">'))
+    blocks:extend(cell)
+    blocks:insert(pandoc.RawBlock("html", "</div>"))
+  end
+  blocks:insert(pandoc.RawBlock("html", "</div>"))
+  return blocks
+end
+
+function Div(div)
+  if not quarto.doc.is_format("hugo-md") then
+    return div
+  end
+
+  local ncol   = div.attributes["layout-ncol"]
+  local layout = div.attributes["layout"]
+
+  -- Only act on divs that carry a layout attribute
+  if not ncol and not layout then
+    return div
+  end
+
+  local valign = div.attributes["layout-valign"]
+  local align_class = (valign == "center") and "items-center" or "items-start"
+
+  -- Pass through any non-layout classes on the outer div
+  -- (e.g. column-body-outset-right), but strip Quarto's own layout classes.
+  local layout_class_prefixes = {
+    "column%-", "layout%-"
+  }
+  local extra_parts = pandoc.List()
+  for _, cls in ipairs(div.classes) do
+    local skip = false
+    for _, prefix in ipairs(layout_class_prefixes) do
+      if cls:match("^" .. prefix) then skip = true; break end
+    end
+    if not skip then
+      extra_parts:insert(cls)
+    end
+  end
+  local extra_classes = table.concat(extra_parts, " ")
+
+  local blocks = pandoc.List()
+
+  if layout then
+    -- layout="[W1,W2]" or layout="[[R1C1,R1C2],[R2C1]]"
+    local rows, is_multi = parse_layout_string(layout)
+
+    if is_multi then
+      -- Multiple rows: each row gets its own grid div.
+      -- We need to split cells across rows according to the row widths.
+      local all_cells = collect_cells(div)
+      local cell_idx = 1
+      for _, weights in ipairs(rows) do
+        local ncols_in_row = #weights
+        local row_cells = pandoc.List()
+        for _ = 1, ncols_in_row do
+          if all_cells[cell_idx] then
+            row_cells:insert(all_cells[cell_idx])
+            cell_idx = cell_idx + 1
+          end
+        end
+        local gcls = weights_to_grid_class(weights)
+        blocks:extend(render_row(row_cells, gcls, align_class, extra_classes))
+        -- Only apply extra_classes (like column-body-outset-right) to the first row
+        extra_classes = ""
+      end
+    else
+      local weights = rows[1]
+      local gcls = weights_to_grid_class(weights)
+      local cells = collect_cells(div)
+      blocks:extend(render_row(cells, gcls, align_class, extra_classes))
+    end
+
+  else
+    -- layout-ncol=N: equal-width columns
+    local weights = pandoc.List()
+    local n = tonumber(ncol) or 2
+    for _ = 1, n do weights:insert("1") end
+    local gcls = "md:grid-cols-" .. n
+    local cells = collect_cells(div)
+    blocks:extend(render_row(cells, gcls, align_class, extra_classes))
+  end
+
+  return blocks
+end

--- a/content/_quarto.yml
+++ b/content/_quarto.yml
@@ -10,3 +10,4 @@ filters:
   - callout
   - video-embed
   - tabset
+  - layout

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -231,6 +231,26 @@ Always include alt text — it's required for accessibility. Use the `fig-alt` a
 ![Optional caption](my-image.png){fig-alt="Alt text describing the image"}
 ```
 
+#### Multi-column layouts
+
+Place content side-by-side with `layout-ncol`. Each child `:::` div becomes one column:
+
+```markdown
+::: {layout-ncol=2}
+
+::: {}
+Left column content — markdown, code blocks, images all work here.
+:::
+
+::: {}
+Right column content.
+:::
+
+:::
+```
+
+A Lua filter converts these to CSS grid at render time, so code blocks (including those with `filename=` attributes) render correctly.
+
 #### Linking to other blog posts
 
 Use the **permalink URL** — the `/blog/YYYY-MM-DD_slug/` path you see in the browser:

--- a/content/blog/great-tables/bring-your-own-df/index.qmd
+++ b/content/blog/great-tables/bring-your-own-df/index.qmd
@@ -6,10 +6,11 @@ people:
   - Michael Chow
 date: '2024-04-24'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/design-philosophy/index.qmd
+++ b/content/blog/great-tables/design-philosophy/index.qmd
@@ -7,10 +7,11 @@ people:
   - Michael Chow
 date: '2024-04-04'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/introduction-0.12.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.12.0/index.qmd
@@ -6,10 +6,11 @@ people:
   - Rich Iannone
 date: '2024-09-30'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/introduction-0.13.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.13.0/index.qmd
@@ -7,10 +7,11 @@ people:
   - Michael Chow
 date: '2024-10-10'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/introduction-0.15.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.15.0/index.qmd
@@ -6,10 +6,11 @@ people:
   - Rich Iannone
 date: '2024-12-19'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/introduction-0.18.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.18.0/index.qmd
@@ -6,10 +6,11 @@ people:
   - Rich Iannone
 date: '2025-07-18'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/introduction-0.2.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.2.0/index.qmd
@@ -6,10 +6,11 @@ people:
   - Rich Iannone
 date: '2024-01-24'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/introduction-0.3.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.3.0/index.qmd
@@ -6,10 +6,11 @@ people:
   - Rich Iannone
 date: '2024-02-16'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/introduction-0.4.0/index.qmd
+++ b/content/blog/great-tables/introduction-0.4.0/index.qmd
@@ -6,10 +6,11 @@ people:
   - Rich Iannone
 date: '2024-03-19'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/latex-output-tables/index.qmd
+++ b/content/blog/great-tables/latex-output-tables/index.qmd
@@ -10,10 +10,11 @@ format:
     code-fold: yes
     code-summary: Show the Code
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/locbody-mask/index.qmd
+++ b/content/blog/great-tables/locbody-mask/index.qmd
@@ -9,10 +9,11 @@ format:
   hugo-md:
     code-summary: Show the Code
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/marimo-and-great-tables/index.qmd
+++ b/content/blog/great-tables/marimo-and-great-tables/index.qmd
@@ -9,10 +9,11 @@ people:
 image: gt_marimo.gif
 image-alt: Screencast showing interactive Great Tables with marimo widgets
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/open-transit-tools/index.qmd
+++ b/content/blog/great-tables/open-transit-tools/index.qmd
@@ -6,10 +6,11 @@ date: '2024-12-19'
 people:
   - Michael Chow
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/plots-in-tables/index.qmd
+++ b/content/blog/great-tables/plots-in-tables/index.qmd
@@ -7,10 +7,11 @@ people:
   - Michael Chow
 date: '2025-07-03'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/pointblank-intro/index.qmd
+++ b/content/blog/great-tables/pointblank-intro/index.qmd
@@ -6,10 +6,11 @@ people:
   - Rich Iannone
 date: '2025-02-11'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/polars-dot-style/index.qmd
+++ b/content/blog/great-tables/polars-dot-style/index.qmd
@@ -6,10 +6,11 @@ people:
   - Michael Chow
 date: '2025-04-16'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/polars-styling/index.qmd
+++ b/content/blog/great-tables/polars-styling/index.qmd
@@ -6,10 +6,11 @@ people:
   - Michael Chow
 date: '2024-01-08'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/pycon-2024-great-tables-are-possible/index.qmd
+++ b/content/blog/great-tables/pycon-2024-great-tables-are-possible/index.qmd
@@ -6,10 +6,11 @@ date: '2024-05-16'
 people:
   - Michael Chow
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/rendering-images/index.qmd
+++ b/content/blog/great-tables/rendering-images/index.qmd
@@ -9,10 +9,11 @@ format:
   hugo-md: 
     code-summary: Show the Code
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/septa-timetables/index.qmd
+++ b/content/blog/great-tables/septa-timetables/index.qmd
@@ -8,10 +8,11 @@ people:
 date: '2026-03-12'
 format: html
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/superbowl-squares/index.qmd
+++ b/content/blog/great-tables/superbowl-squares/index.qmd
@@ -6,10 +6,11 @@ people:
   - Michael Chow
 date: '2024-02-08'
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/great-tables/tables-for-scientific-publishing/index.qmd
+++ b/content/blog/great-tables/tables-for-scientific-publishing/index.qmd
@@ -10,10 +10,11 @@ format:
     code-fold: true
     code-summary: Show the Code
 ported_from: great_tables
+source: great_tables
 port_status: in-progress
 software: ["great-tables"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Great Tables

--- a/content/blog/plotnine/2024-contest-last-call/index.qmd
+++ b/content/blog/plotnine/2024-contest-last-call/index.qmd
@@ -3,10 +3,11 @@ title: ' 2024 Plotnine Contest - Last Call'
 description: "Final call for the 2024 Plotnine Contest—submit your best visualizations by July 26."
 auto-description: true
 date: '2024-07-22'
-categories:
+topics:
   - Visualization
 image: a-spiky-sunset-at-the-beach.png
 ported_from: plotnine
+source: plotnine
 port_status: in-progress
 software: ["plotnine"]
 languages: ["Python"]

--- a/content/blog/plotnine/about-plotnine/index.qmd
+++ b/content/blog/plotnine/about-plotnine/index.qmd
@@ -4,10 +4,11 @@ description: "plotnine: a grammar of graphics implementation for Python built on
 auto-description: true
 date: '2017-04-22'
 ported_from: plotnine
+source: plotnine
 port_status: in-progress
 software: ["plotnine"]
 languages: ["Python"]
-categories:
+topics:
   - Visualization
 tags:
   - Plotnine

--- a/content/blog/plotnine/version-0.14.0/index.qmd
+++ b/content/blog/plotnine/version-0.14.0/index.qmd
@@ -3,9 +3,10 @@ title: Version 0.14.0
 description: "Plotnine v0.14.0: requires Python 3.10+, removes print() for rendering, and improves IDE support for scales."
 auto-description: true
 date: '2024-11-07'
-categories:
+topics:
   - Visualization
 ported_from: plotnine
+source: plotnine
 port_status: in-progress
 software: ["plotnine"]
 languages: ["Python"]

--- a/content/blog/pointblank/all-about-actions/index.qmd
+++ b/content/blog/pointblank/all-about-actions/index.qmd
@@ -6,10 +6,11 @@ people:
   - Rich Iannone
 date: '2025-05-02'
 ported_from: pointblank
+source: pointblank
 port_status: in-progress
 software: ["pointblank"]
 languages: ["Python"]
-categories:
+topics:
   - Data Wrangling
 tags:
   - Pointblank

--- a/content/blog/pointblank/intro-pointblank/index.qmd
+++ b/content/blog/pointblank/intro-pointblank/index.qmd
@@ -6,10 +6,11 @@ people:
   - Rich Iannone
 date: '2025-04-04'
 ported_from: pointblank
+source: pointblank
 port_status: in-progress
 software: ["pointblank"]
 languages: ["Python"]
-categories:
+topics:
   - Data Wrangling
 tags:
   - Pointblank

--- a/content/blog/pointblank/lets-workshop-together/index.qmd
+++ b/content/blog/pointblank/lets-workshop-together/index.qmd
@@ -7,10 +7,11 @@ people:
 date: '2025-06-03'
 toc: no
 ported_from: pointblank
+source: pointblank
 port_status: in-progress
 software: ["pointblank"]
 languages: ["Python"]
-categories:
+topics:
   - Data Wrangling
 tags:
   - Pointblank

--- a/content/blog/pointblank/overhauled-user-guide/index.qmd
+++ b/content/blog/pointblank/overhauled-user-guide/index.qmd
@@ -7,10 +7,11 @@ people:
   - Michael Chow
 date: '2025-05-20'
 ported_from: pointblank
+source: pointblank
 port_status: in-progress
 software: ["pointblank"]
 languages: ["Python"]
-categories:
+topics:
   - Data Wrangling
 tags:
   - Pointblank

--- a/content/blog/pointblank/validation-libs-2025/index.qmd
+++ b/content/blog/pointblank/validation-libs-2025/index.qmd
@@ -6,10 +6,11 @@ people:
   - Rich Iannone
 date: '2025-06-04'
 ported_from: pointblank
+source: pointblank
 port_status: in-progress
 software: ["pointblank"]
 languages: ["Python"]
-categories:
+topics:
   - Data Wrangling
 tags:
   - Pointblank

--- a/content/blog/positron/2026-03-12-notebooks-march-announcement/index.qmd
+++ b/content/blog/positron/2026-03-12-notebooks-march-announcement/index.qmd
@@ -8,10 +8,11 @@ date: "2026-03-16"
 image: positron-notebook.png
 image-alt: "Screenshot of the Positron Notebook Editor interface"
 ported_from: positron
+source: positron
 port_status: in-progress
 software: ["positron"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Best Practices
 tags:
   - Positron

--- a/content/blog/positron/2026-03-31-python-type-checkers/index.qmd
+++ b/content/blog/positron/2026-03-31-python-type-checkers/index.qmd
@@ -8,10 +8,11 @@ date: "2026-03-31"
 image: images/social.png
 image-alt: "Comparison of Python type checkers: Pyrefly, ty, Basedpyright, and Zuban"
 ported_from: positron
+source: positron
 port_status: in-progress
 software: ["positron"]
 languages: ["Python"]
-categories:
+topics:
   - Best Practices
 tags:
   - Positron

--- a/content/blog/positron/2026-04-03-positron-server-jupyterhub/index.qmd
+++ b/content/blog/positron/2026-04-03-positron-server-jupyterhub/index.qmd
@@ -8,10 +8,11 @@ date: "2026-04-06"
 image: images/social.png
 image-alt: "Screenshot of the JupyterHub launcher showing Positron as an available environment alongside JupyterLab"
 ported_from: positron
+source: positron
 port_status: in-progress
 software: ["positron"]
 languages: ["R", "Python"]
-categories:
+topics:
   - MLOps and Admin
 tags:
   - Positron

--- a/content/blog/positron/2026-04-06-april-newsletter/index.qmd
+++ b/content/blog/positron/2026-04-06-april-newsletter/index.qmd
@@ -9,6 +9,7 @@ image: images/addins-support.png
 image-alt: "Positron April Release Highlights"
 slug: april-newsletter
 ported_from: positron
+source: positron
 port_status: in-progress
 software: ["positron"]
 languages: ["R", "Python"]

--- a/content/blog/positron/outgrow-your-laptop/index.qmd
+++ b/content/blog/positron/outgrow-your-laptop/index.qmd
@@ -8,10 +8,11 @@ date: "2026-03-05"
 image: https://img.youtube.com/vi/sPZsH0eaUpQ/hqdefault.jpg
 image-alt: "Talk Recording from R-Ladies Abuja"
 ported_from: positron
+source: positron
 port_status: in-progress
 software: ["positron"]
 languages: ["R", "Python"]
-categories:
+topics:
   - MLOps and Admin
 tags:
   - Positron

--- a/content/blog/quarto/2022-02-13-feature-callouts/index.qmd
+++ b/content/blog/quarto/2022-02-13-feature-callouts/index.qmd
@@ -4,7 +4,7 @@ subtitle: Use callouts to draw attention to important complementary content with
   interupting the document flow
 description: |
   Callouts are an excellent way to draw extra attention to certain concepts, or to more clearly indicate that certain content is supplemental or applicable to only some scenarios.
-categories:
+topics:
   - Publishing
 people:
   - Charles Teague
@@ -15,6 +15,7 @@ image-alt: 'Three calout boxes: A note (has a blue banner with info icon precedi
   and an important (has a red banner with info exclamation-point icon preceding the
   header).'
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2022-02-15-feature-tables/index.qmd
+++ b/content/blog/quarto/2022-02-15-feature-tables/index.qmd
@@ -3,7 +3,7 @@ title: Customizing Table Output
 subtitle: Author and customize markdown tables using Quarto
 description: |
   This post provides an overview of these capabilities in Quarto. For more detail about all the features Quarto for authoring tables, see [Tables](https://quarto.org/docs/authoring/tables.html).
-categories:
+topics:
   - Publishing
 people:
   - JJ Allaire
@@ -12,6 +12,7 @@ image: table.png
 image-alt: 'Table 1: Example. Has two subtables: Subtable a, Cars, with columns for
   speed and dist; and subtable b, Pressure, with columns for temperature and pressure.'
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2022-02-17-advanced-layout/index.qmd
+++ b/content/blog/quarto/2022-02-17-advanced-layout/index.qmd
@@ -7,7 +7,7 @@ description: |
 people:
   - Charles Teague
 date: '2022-02-17'
-categories:
+topics:
   - Publishing
 image: margin-content.png
 image-alt: 'Screenshot of two sections of post: Margin Figures, which has a plot in
@@ -16,6 +16,7 @@ image-alt: 'Screenshot of two sections of post: Margin Figures, which has a plot
 reference-location: margin
 citation-location: margin
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2022-06-21-rstudio-conf-2022-quarto/index.qmd
+++ b/content/blog/quarto/2022-06-21-rstudio-conf-2022-quarto/index.qmd
@@ -3,7 +3,7 @@ title: Quarto at rstudio::conf(2022)
 subtitle: Quarto-related workshops and talks at rstudio::conf(2022)
 description: |
   [rstudio::conf(2022)](https://rstd.io/conf) will feature a variety of workshops and talks on Quarto. Join us in Washington DC this July 25-28 to learn more about Quarto and hear from folks using Quarto to create, share, and collaborate.
-categories:
+topics:
   - Publishing
 people:
   - Mine Çetinkaya-Rundel
@@ -12,6 +12,7 @@ image: conf2022.png
 image-alt: 'rstudio:conf(2022) logo: orange background with the outline of the Washington
   DC skyline.'
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2022-07-25-feature-extensions/index.qmd
+++ b/content/blog/quarto/2022-07-25-feature-extensions/index.qmd
@@ -3,7 +3,7 @@ title: Quarto Extensions
 subtitle: Extend Quarto with new capabilities
 description: |
   Quarto Extensions are a powerful way to modify or extend the behavior of Quarto, and can be created and distributed by anyone. Extension types include filters, shortcodes, and custom formats.
-categories:
+topics:
   - Publishing
 people:
   - JJ Allaire
@@ -12,6 +12,7 @@ image: extensions.png
 image-alt: The main page for the quarto-ext GitHub organization which lists extensions
   published by the Quarto core team.
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2022-10-25-shinylive-extension/index.qmd
+++ b/content/blog/quarto/2022-10-25-shinylive-extension/index.qmd
@@ -3,7 +3,7 @@ title: Shinylive Extension
 subtitle: Embed Shinylive applications in Quarto documents
 description: |
   With Shinylive, you can embed Shiny for Python applications into Quarto documents and run the entire application (including the Python runtime) inside the user's web browser.
-categories:
+topics:
   - Publishing
 people:
   - Winston Chang
@@ -11,6 +11,7 @@ date: '2022-10-25'
 image: shinylive-embedded-app.png
 image-alt: Screenshot of a Quarto document with an embedded Shinylive application.
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto", "shinylive", "shiny-python"]
 languages: ["Python"]

--- a/content/blog/quarto/2023-03-13-code-annotation/index.qmd
+++ b/content/blog/quarto/2023-03-13-code-annotation/index.qmd
@@ -3,7 +3,7 @@ title: Code Annotation
 subtitle: Add line based annotations to your code chunks
 description: |
   In Quarto 1.3, you can add line based annotations to code chunks to highlight or explain parts of your code.
-categories:
+topics:
   - Publishing
 people:
   - Charlotte Wickham
@@ -14,6 +14,7 @@ image-alt: Screenshot a code chunk with annotations. Annotations appear in the c
   text content of the annotations.
 code-annotations: below
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2023-03-15-multi-format/index.qmd
+++ b/content/blog/quarto/2023-03-15-multi-format/index.qmd
@@ -3,7 +3,7 @@ title: Multi-format Publishing
 subtitle: Automatically link to other formats in HTML documents
 description: |
   In Quarto 1.3, additional formats listed in HTML documents will automatically be linked in an "Other Formats" section near the top of the page.
-categories:
+topics:
   - Publishing
 people:
   - Charlotte Wickham
@@ -15,6 +15,7 @@ format:
   ipynb: default
   docx: default
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2023-03-17-jupyter-cell-embedding/index.qmd
+++ b/content/blog/quarto/2023-03-17-jupyter-cell-embedding/index.qmd
@@ -3,7 +3,7 @@ title: Jupyter Notebook Cell Embedding
 subtitle: Embed output from an external Jupyter Notebook in a Quarto document
 description: |
   Quarto 1.3 adds support for embedding cells from a Jupyter Notebook into a Quarto document via an `embed` shortcode. In HTML documents, links are automatically added that point to a rendered version of the external notebook.
-categories:
+topics:
   - Publishing
 people:
   - Charlotte Wickham
@@ -12,6 +12,7 @@ image: embed.png
 image-alt: 'A screenshot of a Quarto page that includes a plot, below the plot is
   the phrase Source: penguins.ipynb.'
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2023-03-20-confluence/index.md
+++ b/content/blog/quarto/2023-03-20-confluence/index.md
@@ -1,8 +1,9 @@
 ---
 title: Confluence Publishing
 subtitle: Publish from Quarto to Confluence
-description: |
-  Quarto 1.3 adds support for publishing individual documents, and projects containing many documents to Atlassian Confluence.
+description: >
+  Quarto 1.3 adds support for publishing individual documents, and projects
+  containing many documents to Atlassian Confluence.
 topics:
   - Publishing
 people:
@@ -13,8 +14,12 @@ image-alt: Atlassian Confluence Logo
 ported_from: quarto
 source: quarto
 port_status: in-progress
-software: ["quarto"]
-languages: ["R", "Python", "Julia"]
+software:
+  - quarto
+languages:
+  - R
+  - Python
+  - Julia
 ported_categories:
   - Features
   - Authoring
@@ -28,59 +33,57 @@ slug: confluence
 ---
 
 
-> **Quarto 1.3 Feature**
->
-> This post is part of a series highlighting new features in the 1.3 release of Quarto. Get the latest release the [download page](https://quarto.org/docs/download/)
+<div class="callout callout-note" role="note" aria-label="Note">
+<div class="callout-header">
+<span class="callout-title">Quarto 1.3 Feature</span>
+</div>
+<div class="callout-body">
+
+This post is part of a series highlighting new features in the 1.3 release of Quarto. Get the latest release the [download page](https://quarto.org/docs/download/)
+
+</div>
+</div>
 
 [Atlassian Confluence](https://www.atlassian.com/software/confluence) is a publishing platform for supporting team collaboration. Confluence has a variety of hosting options which include both free and paid subscription plans.
 
 Quarto 1.3 adds support for publishing individual documents, as well as projects composed of multiple documents into [Confluence Spaces](https://support.atlassian.com/confluence-cloud/docs/use-spaces-to-organize-your-work/).
 
-<table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
 <figure>
 <img src="images/confluence-qmd.png" data-fig-alt="A screenshot of a Quarto document with the title Using R - Doc in the RStudio Editor." alt="A Quarto Document" />
 <figcaption aria-hidden="true">A Quarto Document</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="images/confluence-page.png" data-fig-alt="A screenshot of a document with the title Using R - Doc in a Confluence Space." alt="Published to Confluence" />
 <figcaption aria-hidden="true">Published to Confluence</figcaption>
 </figure>
-</div></td>
-</tr>
-</tbody>
-</table>
 
-<table>
-<colgroup>
-<col style="width: 45%" />
-<col style="width: 54%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="45.2%" data-layout-align="left">
+</div>
+</div>
+<div class="grid gap-12 items-start md:grid-cols-[800fr_969fr]">
+<div class="prose max-w-none">
+
 <figure>
 <img src="images/confluence-project.png" data-fig-alt="A screenshot of a Quarto project in VS Code. On the left in the Explorer, the project folder is called &#39;Guide-site&#39;, and contains folders &#39;authoring&#39;, and &#39;computation&#39;, along with some other files. A document from the folder &#39;python&#39; inside the folder &#39;computations&#39; with the title &#39;Using Python - site&#39; is open in the Source Pane. " alt="A Quarto Project" />
 <figcaption aria-hidden="true">A Quarto Project</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="54.8%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="images/confluence-site.png" data-fig-alt="A screenshot of Space in Confluence. On the left in the Sdiebar under Pages is a page called &#39;Guide-site&#39;. Nested under this page are pages called &#39;authoring&#39;, and &#39;computation&#39;, along with some other pages. The &#39;computation&#39; page item is expanded and shows a page called &#39;Using Python - site&#39;, nested under a page called &#39;python&#39;. A page is displayed on the right with the title &#39;Using Python - site&#39;" alt="Published to Confluence" />
 <figcaption aria-hidden="true">Published to Confluence</figcaption>
 </figure>
-</div></td>
-</tr>
-</tbody>
-</table>
+
+</div>
+</div>
 
 Managing Confluence content with Quarto allows you to author content in Markdown, manage that content with your usual version control tools like Git and GitHub, and leverage Quarto's tools for including computational output.
 

--- a/content/blog/quarto/2023-03-20-confluence/index.qmd
+++ b/content/blog/quarto/2023-03-20-confluence/index.qmd
@@ -3,7 +3,7 @@ title: Confluence Publishing
 subtitle: Publish from Quarto to Confluence
 description: |
   Quarto 1.3 adds support for publishing individual documents, and projects containing many documents to Atlassian Confluence.
-categories:
+topics:
   - Publishing
 people:
   - Charlotte Wickham
@@ -11,6 +11,7 @@ date: '2023-03-20'
 image: confluence-logo-gradient-blue-attribution_rgb@2x.png
 image-alt: Atlassian Confluence Logo
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2023-04-26-1.3-release/index.md
+++ b/content/blog/quarto/2023-04-26-1.3-release/index.md
@@ -90,28 +90,24 @@ Learn more about the embed shortcode in [Embedding Jupyter Notebook Cells](https
 
 [Atlassian Confluence](https://www.atlassian.com/software/confluence) is a publishing platform for supporting team collaboration. Quarto now provides support for publishing individual documents, as well as projects composed of multiple documents, into [Confluence Spaces](https://support.atlassian.com/confluence-cloud/docs/use-spaces-to-organize-your-work/).
 
-<table>
-<colgroup>
-<col style="width: 45%" />
-<col style="width: 54%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="45.2%" data-layout-align="left">
+<div class="grid gap-12 items-start md:grid-cols-[800fr_969fr]">
+<div class="prose max-w-none">
+
 <figure>
 <img src="https://quarto.org/docs/publishing/images/confluence-project.png" data-fig-alt="A screenshot of a Quarto project in VS Code. On the left in the Explorer, the project folder is called &#39;Guide-site&#39;, and contains folders &#39;authoring&#39;, and &#39;computation&#39;, along with some other files. A document from the folder &#39;python&#39; inside the folder &#39;computations&#39; with the title &#39;Using Python - site&#39; is open in the Source Pane. " alt="A Quarto Project" />
 <figcaption aria-hidden="true">A Quarto Project</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="54.8%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="https://quarto.org/docs/publishing/images/confluence-site.png" data-fig-alt="A screenshot of Space in Confluence. On the left in the Sdiebar under Pages is a page called &#39;Guide-site&#39;. Nested under this page are pages called &#39;authoring&#39;, and &#39;computation&#39;, along with some other pages. The &#39;computation&#39; page item is expanded and shows a page called &#39;Using Python - site&#39;, nested under a page called &#39;python&#39;. A page is displayed on the right with the title &#39;Using Python - site&#39;" alt="Published to Confluence" />
 <figcaption aria-hidden="true">Published to Confluence</figcaption>
 </figure>
-</div></td>
-</tr>
-</tbody>
-</table>
+
+</div>
+</div>
 
 To learn more, head to the documentation on [Confluence Publishing](https://quarto.org/docs/publishing/confluence.html).
 

--- a/content/blog/quarto/2023-04-26-1.3-release/index.qmd
+++ b/content/blog/quarto/2023-04-26-1.3-release/index.qmd
@@ -3,7 +3,7 @@ title: Quarto 1.3
 subtitle: Quarto 1.3 is officially released
 description: |
   Quarto 1.3 brings new features, improvements, and fixes.
-categories:
+topics:
   - Publishing
 people:
   - Charlotte Wickham
@@ -11,6 +11,7 @@ date: '2023-04-26'
 image: arthur-chauvineau-Dn7P1U26ZkE-unsplash.jpeg
 image-alt: Fireworks with a silhouette of an audience
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2023-05-15-get-started/index.qmd
+++ b/content/blog/quarto/2023-05-15-get-started/index.qmd
@@ -3,7 +3,7 @@ title: Get Started with Quarto
 subtitle: A video to jumpstart your Quarto journey
 description: |
   A new video for getting started with Quarto using R and RStudio.
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -13,6 +13,7 @@ image: get-started-video-cover.png
 image-alt: Quarto logo on a blue background and the title of the video - Get started
   with Quarto
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2023-05-22-quarto-for-academics/index.qmd
+++ b/content/blog/quarto/2023-05-22-quarto-for-academics/index.qmd
@@ -3,7 +3,7 @@ title: Quarto for Academics
 subtitle: A potpourri of Quarto features useful for academics
 description: |
   A video highlighting some of Quarto's features that are especially useful for academics, as educators and as researchers.
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -13,6 +13,7 @@ image: quarto-for-academics-video-cover.png
 image-alt: Quarto logo on a blue background and the title of the video - Quarto for
   Academics
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2023-12-05-asa-traveling-courses/index.qmd
+++ b/content/blog/quarto/2023-12-05-asa-traveling-courses/index.qmd
@@ -3,7 +3,7 @@ title: ASA Traveling Courses on Quarto
 subtitle: From R Markdown to Quarto
 description: |
   Series of workshops for learning Quarto with R and RStudio, aimed primarily at R Markdown users.
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -12,6 +12,7 @@ date: '2023-12-05'
 image: asa-traveling-courses.png
 image-alt: Screenshots of homepages of six courses titled From R Markdown to Quarto
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2023-12-07-quarto-dashboards-demo/index.qmd
+++ b/content/blog/quarto/2023-12-07-quarto-dashboards-demo/index.qmd
@@ -3,7 +3,7 @@ title: Quarto Dashboards Demonstration
 description: "Video demo of Quarto v1.4's new dashboard feature with Charles Teague."
 auto-description: true
 subtitle: A brief tour of how to build a dashboard in Quarto v1.4.
-categories:
+topics:
   - Publishing
 people:
   - Andrew Holz
@@ -12,6 +12,7 @@ image: quarto-dashboards-video-cover.png
 image-alt: Quarto logo on a blue background with the title Quarto Dashboards, Charles
   Teague and an abstract dashboard sketch
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-01-24-1.4-release/index.md
+++ b/content/blog/quarto/2024-01-24-1.4-release/index.md
@@ -40,26 +40,23 @@ This release has tons of new features. Some of the big ones we want to spotlight
 
 Quarto Dashboards streamline the creation of interactive dashboards, giving you an effortless way to lay out interactive components, visualizations, tabular data, and annotations. Here are some examples (click on the image to visit the live version):
 
-<table style="width:100%;">
-<colgroup>
-<col style="width: 33%" />
-<col style="width: 33%" />
-<col style="width: 33%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: center;"><div width="33.3%" data-layout-align="center">
-<p><a href="https://jjallaire.github.io/stock-explorer-dashboard/"><img src="https://quarto.org/docs/dashboards/examples/thumbnails/stock-explorer-dashboard.png" class="border" data-fig-alt="Screenshot of a Stock Trader dashboard: a row of three values boxes, then a row with a stock ticker graph and a table of closing values. Navy blue and green theme." /></a></p>
-</div></td>
-<td style="text-align: center;"><div width="33.3%" data-layout-align="center">
-<p><a href="https://jjallaire.github.io/customer-churn-dashboard/"><img src="https://quarto.org/docs/dashboards/examples/thumbnails/customer-churn-dashboard.png" class="border" data-fig-alt="Screenshot of a Customer Churn dashboard: a row of three values boxes, then a row with two plots, then a row with a table. Light blue and yellow theme." /></a></p>
-</div></td>
-<td style="text-align: center;"><div width="33.3%" data-layout-align="center">
-<p><a href="https://jjallaire.shinyapps.io/penguins-dashboard/"><img src="https://quarto.org/docs/dashboards/examples/thumbnails/penguins-dashboard.png" class="border" data-fig-alt="Screenshot of a Palmer Penguins dashboard: a sidebar with checkboxes and a dropdown, and two plots in main panel. Blue theme." /></a></p>
-</div></td>
-</tr>
-</tbody>
-</table>
+<div class="grid gap-12 items-start md:grid-cols-3">
+<div class="prose max-w-none">
+
+[<img src="https://quarto.org/docs/dashboards/examples/thumbnails/stock-explorer-dashboard.png" class="border" data-fig-alt="Screenshot of a Stock Trader dashboard: a row of three values boxes, then a row with a stock ticker graph and a table of closing values. Navy blue and green theme." />](https://jjallaire.github.io/stock-explorer-dashboard/)
+
+</div>
+<div class="prose max-w-none">
+
+[<img src="https://quarto.org/docs/dashboards/examples/thumbnails/customer-churn-dashboard.png" class="border" data-fig-alt="Screenshot of a Customer Churn dashboard: a row of three values boxes, then a row with two plots, then a row with a table. Light blue and yellow theme." />](https://jjallaire.github.io/customer-churn-dashboard/)
+
+</div>
+<div class="prose max-w-none">
+
+[<img src="https://quarto.org/docs/dashboards/examples/thumbnails/penguins-dashboard.png" class="border" data-fig-alt="Screenshot of a Palmer Penguins dashboard: a sidebar with checkboxes and a dropdown, and two plots in main panel. Blue theme." />](https://jjallaire.shinyapps.io/penguins-dashboard/)
+
+</div>
+</div>
 
 For the source code of these dashboards and additional examples see the [examples gallery](https://quarto.org/docs/gallery/index.html#dashboards). When you are ready to build your own Quarto dashboard head to our guide on [Dashboards](https://quarto.org/docs/dashboards/index.html).
 
@@ -81,42 +78,40 @@ My first Typst document
 
 We are particularly excited about how easy it is to make templates for journal articles, conference posters, newsletters and more with Typst. Here are some examples you can use in Quarto as [custom formats](https://quarto.org/docs/output-formats/typst-custom.html):
 
-<table>
-<colgroup>
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+<div class="grid gap-12 items-start md:grid-cols-4">
+<div class="prose max-w-none">
+
 <figure>
 <img src="images/typst-format-ieee.png" data-group="custom-formats" data-fig-alt="Screenshot of a page showing a article styled according IEEE standards. The title is centered with authors below in two columns." alt="IEEE" />
 <figcaption aria-hidden="true">IEEE</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="images/typst-format-poster.png" data-group="custom-formats" data-fig-alt="Screenshot of a poster in landscape orientiation. The poster includes a logo in the top right, a title in the top left, and content arranged in three columns." alt="Poster" />
 <figcaption aria-hidden="true">Poster</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="images/typst-format-letter.png" data-group="custom-formats" data-fig-alt="Screenshot of a page showing a letter. A sender address is across the top of the page, followed by a recipient address left justified. The body of the letter includes a subject line in bold." alt="Letter" />
 <figcaption aria-hidden="true">Letter</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="images/typst-format-dept-news.png" data-group="custom-formats" data-fig-alt="Screenshot of a page showing a department newsletter. The page is split vertically with a white column on the left and a red one on the right. An image spans across the column with the text &quot;Award Winning Science&quot; oriented to run vertically down its right side." alt="Dept News" />
 <figcaption aria-hidden="true">Dept News</figcaption>
 </figure>
-</div></td>
-</tr>
-</tbody>
-</table>
+
+</div>
+</div>
 
 Start your Typst journey with Quarto in our guide on [Typst Basics](https://quarto.org/docs/output-formats/typst.html).
 
@@ -124,42 +119,49 @@ Start your Typst journey with Quarto in our guide on [Typst Basics](https://quar
 
 Quarto 1.4 introduces a unified syntax for including computed values inline. The syntax for inline code is similar to code blocks, except you use a single tick (`` ` ``) rather than triple ticks (```` ``` ````), and you can use it in the middle of markdown:
 
-<table style="width:100%;">
-<colgroup>
-<col style="width: 33%" />
-<col style="width: 33%" />
-<col style="width: 33%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="33.3%" data-layout-align="left">
-<h3 id="jupyter">Jupyter</h3>
-<div class="sourceCode" id="cb1"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="in">```{python}</span></span>
-<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>radius <span class="op">=</span> <span class="dv">5</span></span>
-<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span>
-<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>The radius of the circle is <span class="in">`{python} radius`</span></span></code></pre></div>
-<p>This syntax works for any Jupyter kernel—so for Julia you would write an inline expression as <code>`{julia} radius`</code>).</p>
-</div></td>
-<td style="text-align: left;"><div width="33.3%" data-layout-align="left">
-<h3 id="knitr">Knitr</h3>
-<div class="sourceCode" id="cb2"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="in">```{r}</span></span>
-<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>radius <span class="ot">&lt;-</span> <span class="dv">5</span></span>
-<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span>
-<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a>The radius of the circle is <span class="in">`{r} radius`</span></span></code></pre></div>
-</div></td>
-<td style="text-align: left;"><div width="33.3%" data-layout-align="left">
-<h3 id="ojs">OJS</h3>
-<div class="sourceCode" id="cb3"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="in">```{ojs}</span></span>
-<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>radius <span class="op">=</span> <span class="dv">5</span></span>
-<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span>
-<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>The radius of the circle is <span class="in">`{ojs} radius`</span></span></code></pre></div>
-</div></td>
-</tr>
-</tbody>
-</table>
+<div class="grid gap-12 items-start md:grid-cols-3">
+<div class="prose max-w-none">
+
+### Jupyter
+
+```` markdown
+```{python}
+radius = 5
+```
+
+The radius of the circle is `{python} radius`
+````
+
+This syntax works for any Jupyter kernel---so for Julia you would write an inline expression as `` `{julia} radius` ``).
+
+</div>
+<div class="prose max-w-none">
+
+### Knitr
+
+```` markdown
+```{r}
+radius <- 5
+```
+
+The radius of the circle is `{r} radius`
+````
+
+</div>
+<div class="prose max-w-none">
+
+### OJS
+
+```` markdown
+```{ojs}
+radius = 5
+```
+
+The radius of the circle is `{ojs} radius`
+````
+
+</div>
+</div>
 
 And don't worry if you are used to using `` `r ` `` that syntax remains fully supported. Read more at [Inline Code](https://quarto.org/docs/computations/inline-code.html).
 
@@ -167,33 +169,19 @@ And don't worry if you are used to using `` `r ` `` that syntax remains fully su
 
 Cross-references have been overhauled in Quarto 1.4, enabling you to do things like:
 
-- Flexibly define the content of float cross-references (e.g. figures, tables and code listings) with the new [Cross-Reference Div Syntax](https://quarto.org/docs/authoring/cross-references-divs.html). For example, <a href="#tbl-table" class="quarto-xref">Table 1</a> is an image treated like a table:
+- Flexibly define the content of float cross-references (e.g. figures, tables and code listings) with the new [Cross-Reference Div Syntax](https://quarto.org/docs/authoring/cross-references-divs.html). For example, **?@tbl-table** is an image treated like a table:
 
-  <table>
-  <colgroup>
-  <col style="width: 50%" />
-  <col style="width: 50%" />
-  </colgroup>
-  <tbody>
-  <tr>
-  <td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-  <div class="sourceCode" id="cb1"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>::: {#tbl-table}</span>
-  <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a></span>
-  <span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="al">![](table.png)</span></span>
-  <span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a></span>
-  <span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>An image treated like a table</span>
-  <span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a></span>
-  <span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a>:::</span></code></pre></div>
-  </div></td>
-  <td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-  <img src="images/crossref-div-table.png" id="tbl-table"
-  alt="Table 1: An image treated like a table" />
-  &#10;</div></td>
-  </tr>
-  </tbody>
-  </table>
+  <div class="grid gap-12 items-start md:grid-cols-2">
+  <div class="prose max-w-none">
 
-  And notice if you hover over the reference as it appears in the text, e.g. hover over this link to <a href="#tbl-table" class="quarto-xref">Table 1</a>, you'll get a floating preview of the content---that's new too.
+  ![](images/crossref-div-table.png)
+
+  An image treated like a table
+
+  </div>
+  </div>
+
+  And notice if you hover over the reference as it appears in the text, e.g. hover over this link to **?@tbl-table**, you'll get a floating preview of the content---that's new too.
 
 - Define [custom types of float cross-reference](https://quarto.org/docs/authoring/cross-references-custom.html), which you could use to create cross-references to Videos, Diagrams or [Supplemental Figures](https://quarto.org/docs/authoring/cross-references-custom.html#example-supplemental-figures).
 
@@ -205,28 +193,24 @@ Quarto manuscript projects provide a framework for writing and publishing schola
 
 The output of a manuscript project is a website containing the article in multiple formats (e.g. LaTeX, MS Word) along with rendered versions of the notebooks in the project:
 
-<table>
-<colgroup>
-<col style="width: 75%" />
-<col style="width: 25%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="75.0%" data-layout-align="left">
+<div class="grid gap-12 items-start md:grid-cols-[3fr_1fr]">
+<div class="prose max-w-none">
+
 <figure>
 <img src="images/article-content.png" class="border" data-fig-alt="A screenshot of the content area on the manuscript webpage. Content shows a title block including the article title, authors, and abstract, body text, and an image with a caption." alt="Article Content" />
 <figcaption aria-hidden="true">Article Content</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="images/webpage-menu.png" class="border" data-fig-alt="A screenshot of the menu on the right hand side of the manuscript webpage. The menu has headings: Table of contents, Other Formats, Notebooks and Other Links." alt="Navigation" />
 <figcaption aria-hidden="true">Navigation</figcaption>
 </figure>
-</div></td>
-</tr>
-</tbody>
-</table>
+
+</div>
+</div>
 
 Read more about manuscripts and how to get started in our guide to [Manuscripts](https://quarto.org/docs/manuscripts/index.html).
 

--- a/content/blog/quarto/2024-01-24-1.4-release/index.qmd
+++ b/content/blog/quarto/2024-01-24-1.4-release/index.qmd
@@ -3,7 +3,7 @@ title: Quarto 1.4
 subtitle: Quarto 1.4 is released
 description: |
   Quarto 1.4 brings new formats for dashboards and Typst, a new manuscript project type, a cross-reference overhaul, Shiny for Python support, and a ton of other updates.
-categories:
+topics:
   - Publishing
 people:
   - Charlotte Wickham
@@ -11,6 +11,7 @@ date: '2024-01-24'
 image: images/thumbnail.png
 image-alt: Quarto 1.4 with a party popper
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-03-26-hugging-face/index.qmd
+++ b/content/blog/quarto/2024-03-26-hugging-face/index.qmd
@@ -8,10 +8,11 @@ date: '2024-03-26'
 image: images/hugging-face-thumb.png
 image-alt: Hugging Face Logo
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]
-categories:
+topics:
   - Publishing
 tags:
   - Quarto

--- a/content/blog/quarto/2024-04-01-manuscripts-rmedicine/index.qmd
+++ b/content/blog/quarto/2024-04-01-manuscripts-rmedicine/index.qmd
@@ -8,10 +8,11 @@ date: '2024-04-01'
 image: images/manuscripts-thumbnail.png
 image-alt: From multiple Quarto documents and scripts in R and python to PDF or Word
   output.
-categories:
+topics:
   - Publishing
   - Community
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-05-28-conf-workshops/index.qmd
+++ b/content/blog/quarto/2024-05-28-conf-workshops/index.qmd
@@ -9,10 +9,11 @@ date: '2024-05-28'
 image: images/conf-workshops-thumbnail.png
 image-alt: posit::conf(2024) iconography including Seattle skyline on the left and
   the words 'Quarto workshops' on the right.
-categories:
+topics:
   - Publishing
   - Community
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-07-02-beautiful-tables-in-typst/index.md
+++ b/content/blog/quarto/2024-07-02-beautiful-tables-in-typst/index.md
@@ -8,10 +8,6 @@ date: '2024-07-02'
 image: beautiful-tables-typst.png
 image-alt: typst snapshot tk
 bibliography: []
-format:
-  html:
-    css: layout.css
-    number-sections: yes
 topics:
   - Publishing
 ported_categories:
@@ -20,8 +16,12 @@ ported_categories:
 ported_from: quarto
 source: quarto
 port_status: raw
-software: ["quarto"]
-languages: ["R", "Python", "Julia"]
+software:
+  - quarto
+languages:
+  - R
+  - Python
+  - Julia
 tags:
   - Quarto
   - Quarto 1.5
@@ -42,70 +42,118 @@ You can click on the links below the examples to see the full documents, with so
 
 This example uses a dashed border to draw attention to two cells.
 
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
 <img src="images/pandas-confusion-matrix.png" width="700" /> <a href="examples/pandas-confusion-matrix.pdf" target="_blank">Typst</a>
 
+</div>
+<div class="prose max-w-none">
 <iframe class="html-demo" src="demo/pandas-confusion-matrix.html" width=700 height=250 scrolling="no"></iframe>
 
-<a href="examples/pandas-confusion-matrix.html" target="_blank">HTML</a>
+<a href="examples/pandas-confusion-matrix.HTML" target="_blank">HTML</a>
+
+</div>
+</div>
 
 ## Cars heatmap (gt / R)
 
 This example uses cell background colors to encode ranges of values.
 
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
 <img src="images/gt-cars.png" width="430" />
 
 <a href="examples/gt-cars.pdf" target="_blank">Typst</a>
 
+</div>
+<div class="prose max-w-none">
 <iframe class="html-demo" src="demo/gt-cars.html" width=430 height=375 scrolling="no"></iframe>
 
-<a href="examples/gt-cars.html" target="_blank">HTML</a>
+<a href="examples/gt-cars.HTML" target="_blank">HTML</a>
+
+</div>
+</div>
 
 ## Oceania (Great Tables / Python)
 
 Borders can show the structure of grouped rows.
 
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
 <img src="images/great-tables-oceania.png" width="600" />
 
 <a href="examples/great-tables-oceania.pdf" target="_blank">Typst</a>
 
+</div>
+<div class="prose max-w-none">
 <iframe class="html-demo" src="demo/great-tables-oceania.html" width=600 height=907 scrolling="no"></iframe>
 
-<a href="examples/great-tables-oceania.html" target="_blank">HTML</a>
+<a href="examples/great-tables-oceania.HTML" target="_blank">HTML</a>
+
+</div>
+</div>
 
 ## Islands (gt / R)
 
 Font sizes and minimal borders make this table stand out.
 
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
 <img src="images/gt-islands.png" width="500" />
 
 <a href="examples/gt-islands.pdf" target="_blank">Typst</a>
 
+</div>
+<div class="prose max-w-none">
 <iframe class="html-demo" src="demo/gt-islands.html" width=400 height=580 scrolling="no"></iframe>
 
-<a href="examples/gt-islands.html" target="_blank">HTML</a>
+<a href="examples/gt-islands.HTML" target="_blank">HTML</a>
+
+</div>
+</div>
 
 ## Solar Zenith (Great Tables / Python)
 
 Another cool heatmap.
 
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
 <img src="images/great-tables-solar-zenith.png" width="750" />
 
 <a href="examples/great-tables-solar-zenith.pdf" target="_blank">Typst</a>
 
+</div>
+<div class="prose max-w-none">
 <iframe class="html-demo" src="demo/great-tables-solar-zenith.html" width=850 height=565 scrolling="no"></iframe>
 
-<a href="examples/great-tables-solar-zenith.html" target="_blank">HTML</a>
+<a href="examples/great-tables-solar-zenith.HTML" target="_blank">HTML</a>
+
+</div>
+</div>
 
 ## Acting on Data (Pandas / Python)
 
 Applying colors and transparency based on data.
 
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
 <img src="images/pandas-acting-on-data.png" width="540" />
 
 <a href="examples/pandas-acting-on-data.pdf" target="_blank">Typst</a>
 
+</div>
+<div class="prose max-w-none">
 <iframe class="html-demo" src="demo/pandas-acting-on-data.html" width=600 height=505 scrolling="no"></iframe>
 
-<a href="examples/pandas-acting-on-data.html" target="_blank">HTML</a>
+<a href="examples/pandas-acting-on-data.HTML" target="_blank">HTML</a>
+
+</div>
+</div>
 
 We can't wait to see what you do with this new feature!

--- a/content/blog/quarto/2024-07-02-beautiful-tables-in-typst/index.qmd
+++ b/content/blog/quarto/2024-07-02-beautiful-tables-in-typst/index.qmd
@@ -8,10 +8,6 @@ date: '2024-07-02'
 image: beautiful-tables-typst.png
 image-alt: typst snapshot tk
 bibliography: []
-format:
-  html:
-    css: layout.css
-    number-sections: yes
 topics:
   - Publishing
 ported_categories:

--- a/content/blog/quarto/2024-07-02-beautiful-tables-in-typst/index.qmd
+++ b/content/blog/quarto/2024-07-02-beautiful-tables-in-typst/index.qmd
@@ -12,12 +12,13 @@ format:
   html:
     css: layout.css
     number-sections: yes
-categories:
+topics:
   - Publishing
 ported_categories:
   - Quarto 1.5
   - Tables
 ported_from: quarto
+source: quarto
 port_status: raw
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-07-11-1.5-release/index.qmd
+++ b/content/blog/quarto/2024-07-11-1.5-release/index.qmd
@@ -3,7 +3,7 @@ title: Quarto 1.5
 description: "Quarto 1.5 improves Typst support, has some website enhancements like
   draft handling and announcement bars, adds a native Julia engine, and adds a couple
   of shortcodes for generating placeholder content. \n"
-categories:
+topics:
   - Publishing
 people:
   - Charlotte Wickham
@@ -11,6 +11,7 @@ date: '2024-07-11'
 image: images/thumbnail.png
 image-alt: Quarto 1.5 with a balloon
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-10-15-conf-workshops-materials/index.md
+++ b/content/blog/quarto/2024-10-15-conf-workshops-materials/index.md
@@ -1,7 +1,8 @@
 ---
 title: posit::conf(2024) Quarto workshop materials
-description: |
-  Back in August, we hosted three Quarto workshops at posit::conf(2024); the materials from those workshops are available to learn and teach from!
+description: >
+  Back in August, we hosted three Quarto workshops at posit::conf(2024); the
+  materials from those workshops are available to learn and teach from!
 topics:
   - Publishing
   - Community
@@ -14,8 +15,12 @@ image-alt: 'posit::conf(2024) logo '
 ported_from: quarto
 source: quarto
 port_status: in-progress
-software: ["quarto"]
-languages: ["R", "Python", "Julia"]
+software:
+  - quarto
+languages:
+  - R
+  - Python
+  - Julia
 ported_categories:
   - Learn
   - Workshop
@@ -29,74 +34,63 @@ slug: conf-workshops-materials
 
 This year at posit::conf(2024) we had three day-long Quarto workshops. The materials from those workshops are available for all to learn from. Additionally, you're welcomed to use them in full or part when talking or teaching about Quarto; they are all released with a [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license.
 
-<table>
-<colgroup>
-<col style="width: 70%" />
-<col style="width: 30%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="70.0%" data-layout-align="left">
-<p><a href="https://posit-conf-2024.github.io/quarto-intro/" data-heading="Introduction to Quarto"><strong>Introduction to Quarto</strong></a></p>
-<p><a href="https://posit-conf-2024.github.io/quarto-intro" class="uri">https://posit-conf-2024.github.io/quarto-intro</a></p>
-<p><br />
-</p>
-<ul>
-<li><p>Led by <a href="https://bids.berkeley.edu/people/andrew-bray">Andrew Bray</a>, UC Berkeley</p></li>
-<li><p>Ideal for beginners looking to create rich documents</p></li>
-</ul>
-</div></td>
-<td style="text-align: center;"><div width="30.0%" data-layout-align="center">
-<p><a href="https://posit-conf-2024.github.io/quarto-intro/"><img src="images/intro.png" data-fig-alt="Illustration of a seaplane." /></a></p>
-</div></td>
-</tr>
-</tbody>
-</table>
+<div class="grid gap-12 items-start md:grid-cols-[70fr_30fr]">
+<div class="prose max-w-none">
 
-<table>
-<colgroup>
-<col style="width: 70%" />
-<col style="width: 30%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="70.0%" data-layout-align="left">
-<p><a href="https://posit-conf-2024.github.io/quarto-dashboards/"><strong>Build-a-Dashboard Workshop (with Quarto, R, and/or Python)</strong></a></p>
-<p><a href="https://posit-conf-2024.github.io/quarto-dashboards/">https://posit-conf-2024.github.io/quarto-dashboards</a></p>
-<p><br />
-</p>
-<ul>
-<li><p>Led by <a href="https://mine-cr.com/">Mine Çetinkaya-Rundel</a>, Posit, PBC, Duke University</p></li>
-<li><p>Perfect for those familiar with computational notebooks in R and/or Python who want to create eye-catching dashboards</p></li>
-</ul>
-</div></td>
-<td style="text-align: center;"><div width="30.0%" data-layout-align="center">
-<p><a href="https://posit-conf-2024.github.io/quarto-dashboards/"><img src="images/dashboards.png" data-fig-alt="An illustration of a dashboard made with Quarto" /></a></p>
-</div></td>
-</tr>
-</tbody>
-</table>
+<a href="https://posit-conf-2024.github.io/quarto-intro/" data-heading="Introduction to Quarto"><strong>Introduction to Quarto</strong></a>
 
-<table>
-<colgroup>
-<col style="width: 70%" />
-<col style="width: 30%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="70.0%" data-layout-align="left">
-<p><a href="https://posit-conf-2024.github.io/quarto-websites/" data-heading="Quarto Websites"><strong>Quarto Websites</strong></a></p>
-<p><a href="https://posit-conf-2024.github.io/quarto-websites/">https://posit-conf-2024.github.io/quarto-websites</a></p>
-<p><br />
-</p>
-<ul>
-<li><p>Led by <a href="https://www.cwick.co.nz/">Charlotte Wickham</a> and <a href="https://emilhvitfeldt.com/">Emil Hvitfeldt</a>, Posit, PBC</p></li>
-<li><p>Great choice for those wanting to build a website from scratch with Quarto</p></li>
-</ul>
-</div></td>
-<td style="text-align: center;"><div width="30.0%" data-layout-align="center">
-<p><a href="https://posit-conf-2024.github.io/quarto-websites/"><img src="images/websites.png" data-fig-alt="A diagram showing switching between navbar and sidebar navigation for a Quarto website." /></a></p>
-</div></td>
-</tr>
-</tbody>
-</table>
+<https://posit-conf-2024.github.io/quarto-intro>
+
+  
+
+- Led by [Andrew Bray](https://bids.berkeley.edu/people/andrew-bray), UC Berkeley
+
+- Ideal for beginners looking to create rich documents
+
+</div>
+<div class="prose max-w-none">
+
+[<img src="images/intro.png" data-fig-alt="Illustration of a seaplane." />](https://posit-conf-2024.github.io/quarto-intro/)
+
+</div>
+</div>
+<div class="grid gap-12 items-start md:grid-cols-[70fr_30fr]">
+<div class="prose max-w-none">
+
+[**Build-a-Dashboard Workshop (with Quarto, R, and/or Python)**](https://posit-conf-2024.github.io/quarto-dashboards/)
+
+[https://posit-conf-2024.github.io/quarto-dashboards](https://posit-conf-2024.github.io/quarto-dashboards/)
+
+  
+
+- Led by [Mine Çetinkaya-Rundel](https://mine-cr.com/), Posit, PBC, Duke University
+
+- Perfect for those familiar with computational notebooks in R and/or Python who want to create eye-catching dashboards
+
+</div>
+<div class="prose max-w-none">
+
+[<img src="images/dashboards.png" data-fig-alt="An illustration of a dashboard made with Quarto" />](https://posit-conf-2024.github.io/quarto-dashboards/)
+
+</div>
+</div>
+<div class="grid gap-12 items-start md:grid-cols-[70fr_30fr]">
+<div class="prose max-w-none">
+
+<a href="https://posit-conf-2024.github.io/quarto-websites/" data-heading="Quarto Websites"><strong>Quarto Websites</strong></a>
+
+[https://posit-conf-2024.github.io/quarto-websites](https://posit-conf-2024.github.io/quarto-websites/)
+
+  
+
+- Led by [Charlotte Wickham](https://www.cwick.co.nz/) and [Emil Hvitfeldt](https://emilhvitfeldt.com/), Posit, PBC
+
+- Great choice for those wanting to build a website from scratch with Quarto
+
+</div>
+<div class="prose max-w-none">
+
+[<img src="images/websites.png" data-fig-alt="A diagram showing switching between navbar and sidebar navigation for a Quarto website." />](https://posit-conf-2024.github.io/quarto-websites/)
+
+</div>
+</div>

--- a/content/blog/quarto/2024-10-15-conf-workshops-materials/index.qmd
+++ b/content/blog/quarto/2024-10-15-conf-workshops-materials/index.qmd
@@ -2,7 +2,7 @@
 title: posit::conf(2024) Quarto workshop materials
 description: |
   Back in August, we hosted three Quarto workshops at posit::conf(2024); the materials from those workshops are available to learn and teach from!
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -12,6 +12,7 @@ date: '2024-10-15'
 image: images/thumbnail.png
 image-alt: 'posit::conf(2024) logo '
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-11-06-conf-talks/index.qmd
+++ b/content/blog/quarto/2024-11-06-conf-talks/index.qmd
@@ -2,7 +2,7 @@
 title: posit::conf(2024) Quarto talks
 description: |
   Videos of talks from posit::conf(2024) are posted, we've compiled a playlist of Quarto talks for you!
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -12,6 +12,7 @@ date: '2024-11-06'
 image: images/thumbnail.jpg
 image-alt: Collage of speakers with Quarto talks at posit::conf(2024)
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-11-22-dashboards-workshop/index.qmd
+++ b/content/blog/quarto/2024-11-22-dashboards-workshop/index.qmd
@@ -2,7 +2,7 @@
 title: Quarto dashboards video series
 description: |
   Learn how to build a Quarto dashboard with a three-part video series.
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -12,6 +12,7 @@ date: '2024-11-22'
 image: quarto-dashboards.jpg
 image-alt: Build a dashboard workshop with Quarto, R and/or Python.
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-11-25-1.6-release/index.md
+++ b/content/blog/quarto/2024-11-25-1.6-release/index.md
@@ -76,42 +76,40 @@ typography:
 
 When this `_brand.yml` is placed in a project, webpages, presentations, PDF reports, and dashboards will share a common appearance:
 
-<table>
-<colgroup>
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+<div class="grid gap-12 items-start md:grid-cols-4">
+<div class="prose max-w-none">
+
 <figure>
 <img src="https://quarto.org/docs/authoring/images/brand-html.png" data-group="brand-formats" data-fig-alt="Screenshot of a webpage. The text is dark grey on a light blue background, using a rounded sans-serif typeface, a logo appears in the navbar." alt="Webpage: html" />
 <figcaption aria-hidden="true">Webpage: <code>html</code></figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="https://quarto.org/docs/authoring/images/brand-dashboard.png" data-group="brand-formats" data-fig-alt="Screenshot of a dashboard. The text is dark grey on a light blue background, using a rounded sans-serif typeface, a logo appears in the navbar." alt="Dashboard dashboard" />
 <figcaption aria-hidden="true">Dashboard <code>dashboard</code></figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="https://quarto.org/docs/authoring/images/brand-revealjs.png" data-group="brand-formats" data-fig-alt="Screenshot of a presentation. The text is dark grey on a light blue background, using a rounded sans-serif typeface, a logo appears in bottom left of the slide." alt="Presentation: revealjs" />
 <figcaption aria-hidden="true">Presentation: <code>revealjs</code></figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="https://quarto.org/docs/authoring/images/brand-typst.png" data-group="brand-formats" data-fig-alt="Screenshot of a PDF document. The text is dark grey on a light blue background, using a rounded sans-serif typeface, a logo appears in top right of the page." alt="PDF: typst" />
 <figcaption aria-hidden="true">PDF: <code>typst</code></figcaption>
 </figure>
-</div></td>
-</tr>
-</tbody>
-</table>
+
+</div>
+</div>
 
 View the example: [Source](https://github.com/quarto-dev/quarto-examples/tree/main/brand/brand-simple#brand-simple) \| [Live website](https://examples.quarto.pub/brand-simple)
 

--- a/content/blog/quarto/2024-11-25-1.6-release/index.qmd
+++ b/content/blog/quarto/2024-11-25-1.6-release/index.qmd
@@ -2,7 +2,7 @@
 title: Quarto 1.6
 description: |
   Quarto 1.6 supports unified branding across formats, updates to RevealJS, a new shortcode to reorder content, a landscape page block, and more. There are also a couple of breaking changes that will affect a small number of users.
-categories:
+topics:
   - Publishing
 people:
   - Charlotte Wickham
@@ -10,6 +10,7 @@ date: '2024-11-25'
 image: thumbnail.png
 image-alt: Quarto 1.6 with a palette.
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-12-04-websites-workshop/index.qmd
+++ b/content/blog/quarto/2024-12-04-websites-workshop/index.qmd
@@ -2,7 +2,7 @@
 title: Quarto website video series
 description: |
   Build a personal website with Quarto by following this four-part video series on YouTube.
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -12,6 +12,7 @@ date: '2024-12-04'
 image: quarto-websites.jpg
 image-alt: Quarto Websites Workshop
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2024-12-12-includes-meta/index.qmd
+++ b/content/blog/quarto/2024-12-12-includes-meta/index.qmd
@@ -2,7 +2,7 @@
 title: Use `meta` + `include` to customize reusable content
 description: |
   The "Includes" feature in Quarto lets you efficiently reuse content across multiple files. Combined with the "meta" shortcode, it enables you to set precise, file-specific values.
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -11,6 +11,7 @@ date: '2024-12-12'
 image: thumbnail.jpg
 image-alt: Quarto logo with single source publishing icon.
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2025-01-15-quarto-tip-brand-positron/index.qmd
+++ b/content/blog/quarto/2025-01-15-quarto-tip-brand-positron/index.qmd
@@ -3,7 +3,7 @@ title: Tip - use Positron to choose colors for your project brand
 description: |
   Use Positron's integrated color picker for an easy way to choose colors for
   your next project's `_brand.yml`.
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -11,6 +11,7 @@ people:
 date: '2025-01-15'
 image: brand.png
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto", "positron", "brand-yml"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2025-04-28-1.7-release/index.md
+++ b/content/blog/quarto/2025-04-28-1.7-release/index.md
@@ -57,28 +57,24 @@ brand:
 
 Standalone HTML pages, websites, and dashboards will gain a light switch toggle allowing viewers to switch between the light and dark themes.
 
-<table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
 <figure>
 <img src="light.png" data-fig-alt="Screenshot of a webpage with a light blue body and charcoal text. A switch toggle in the navbar is &#39;off&#39;." alt="light brand" />
 <figcaption aria-hidden="true"><code>light</code> brand</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="dark.png" data-fig-alt="Screenshot of a webpage with a dark charcoal body and light blue text. A switch toggle in the navbar is &#39;on&#39;." alt="dark brand" />
 <figcaption aria-hidden="true"><code>dark</code> brand</figcaption>
 </figure>
-</div></td>
-</tr>
-</tbody>
-</table>
+
+</div>
+</div>
 
 By default Typst documents will use the light brand, but you can set the `brand-mode` option to use the dark brand instead:
 
@@ -137,22 +133,13 @@ format:
 
 - New [`version` shortcode](https://quarto.org/docs/authoring/version.html) to insert the version of Quarto used to build your document:
 
-  <table>
-  <colgroup>
-  <col style="width: 50%" />
-  <col style="width: 50%" />
-  </colgroup>
-  <tbody>
-  <tr>
-  <td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-  <div class="sourceCode" id="cb1" data-shortcodes="false"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>Rendered with Quarto {{&lt;/* version */&gt;}}</span></code></pre></div>
-  </div></td>
-  <td style="text-align: left;"><div class="border" width="50.0%" data-layout-align="left">
-  <p>Rendered with Quarto 1.9.36</p>
-  </div></td>
-  </tr>
-  </tbody>
-  </table>
+  <div class="grid gap-12 items-center md:grid-cols-2">
+  <div class="prose max-w-none">
+
+  Rendered with Quarto 1.9.36
+
+  </div>
+  </div>
 
 - Updated LaTeX and Beamer template partials:
 

--- a/content/blog/quarto/2025-04-28-1.7-release/index.qmd
+++ b/content/blog/quarto/2025-04-28-1.7-release/index.qmd
@@ -2,7 +2,7 @@
 title: Quarto 1.7
 description: |
   Quarto 1.7 brings big improvements to dark mode along with updates to Typst, Pandoc, a new `version` shortcode, and improvements to the `julia` engine.
-categories:
+topics:
   - Publishing
 people:
   - Charlotte Wickham
@@ -12,6 +12,7 @@ image: thumbnail-1.7.jpeg
 image-alt: 'Quarto 1.7: half the Quarto logo is light on dark, the other half dark
   on light'
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2025-05-19-quarto-codespaces/index.md
+++ b/content/blog/quarto/2025-05-19-quarto-codespaces/index.md
@@ -11,7 +11,6 @@ topics:
 image: featured.png
 image-alt: |
   Quarto icon and text above GitHub Codespaces.
-lang: en-GB
 ported_from: quarto
 source: quarto
 port_status: in-progress

--- a/content/blog/quarto/2025-05-19-quarto-codespaces/index.md
+++ b/content/blog/quarto/2025-05-19-quarto-codespaces/index.md
@@ -2,19 +2,25 @@
 people:
   - Mickaël CANOUIL, _Ph.D._
 title: How to use GitHub Codespaces to simplify your Quarto workshops
-description: |
-  In this post, I'll teach you the basics of GitHub Codespaces and how to use them to make it easier to teach using Quarto.
+description: >
+  In this post, I'll teach you the basics of GitHub Codespaces and how to use
+  them to make it easier to teach using Quarto.
 date: '2025-05-19'
 topics:
   - Publishing
 image: featured.png
 image-alt: |
   Quarto icon and text above GitHub Codespaces.
+lang: en-GB
 ported_from: quarto
 source: quarto
 port_status: in-progress
-software: ["quarto"]
-languages: ["R", "Python", "Julia"]
+software:
+  - quarto
+languages:
+  - R
+  - Python
+  - Julia
 ported_categories:
   - GitHub Codespaces
   - Teaching
@@ -69,22 +75,18 @@ The following link will create a new Codespace using the `.devcontainer/universa
 The link can include a specific branch, a particular file, or even a specific line in a file, allowing you to guide participants directly to the relevant content and setup.
 By doing nothing more than clicking that one link, participants create or resume an existing execution environment.
 
-<table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: center;"><div width="50.0%" data-layout-align="center">
-<p><img src="quarto-codespaces-new-001-light.png" data-group="codespaces-light" data-fig-alt="GitHub Codespaces interface showing the &#39;Create codespace&#39; page. The page includes a section with the repository &#39;mcanouil/quarto-codespaces&#39; and a message stating &#39;No codespace to resume&#39;. There are two buttons: &#39;Change options&#39; and &#39;Create new codespace&#39;." /></p>
-</div></td>
-<td style="text-align: center;"><div width="50.0%" data-layout-align="center">
-<p><img src="quarto-codespaces-new-002-light.png" data-group="codespaces-light" data-fig-alt="image_url" alt="Screenshot of Visual Studio Code interface showing a GitHub Codespace for a project named &#39;quarto-codespaces&#39;. The left sidebar contains a file explorer with folders and files such as .devcontainer, .github, init-env.sh, LICENSE, and README.md. The terminal at the bottom displays logs related to configuring the codespace, including commands and their outcomes. The right sidebar has a section titled &#39;Edit with Copilot&#39; explaining how to use Copilot in agent mode." /></p>
-</div></td>
-</tr>
-</tbody>
-</table>
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
+<img src="quarto-codespaces-new-001-light.png" data-group="codespaces-light" data-fig-alt="GitHub Codespaces interface showing the &#39;Create codespace&#39; page. The page includes a section with the repository &#39;mcanouil/quarto-codespaces&#39; and a message stating &#39;No codespace to resume&#39;. There are two buttons: &#39;Change options&#39; and &#39;Create new codespace&#39;." />
+
+</div>
+<div class="prose max-w-none">
+
+<img src="quarto-codespaces-new-002-light.png" data-group="codespaces-light" data-fig-alt="image_url" alt="Screenshot of Visual Studio Code interface showing a GitHub Codespace for a project named &#39;quarto-codespaces&#39;. The left sidebar contains a file explorer with folders and files such as .devcontainer, .github, init-env.sh, LICENSE, and README.md. The terminal at the bottom displays logs related to configuring the codespace, including commands and their outcomes. The right sidebar has a section titled &#39;Edit with Copilot&#39; explaining how to use Copilot in agent mode." />
+
+</div>
+</div>
 
 ## Setting Up Your Own Quarto-Codespaces Environment
 

--- a/content/blog/quarto/2025-05-19-quarto-codespaces/index.qmd
+++ b/content/blog/quarto/2025-05-19-quarto-codespaces/index.qmd
@@ -10,7 +10,6 @@ topics:
 image: featured.png
 image-alt: |
   Quarto icon and text above GitHub Codespaces.
-lang: en-GB
 ported_from: quarto
 source: quarto
 port_status: in-progress

--- a/content/blog/quarto/2025-05-19-quarto-codespaces/index.qmd
+++ b/content/blog/quarto/2025-05-19-quarto-codespaces/index.qmd
@@ -5,13 +5,14 @@ title: How to use GitHub Codespaces to simplify your Quarto workshops
 description: |
   In this post, I'll teach you the basics of GitHub Codespaces and how to use them to make it easier to teach using Quarto.
 date: '2025-05-19'
-categories:
+topics:
   - Publishing
 image: featured.png
 image-alt: |
   Quarto icon and text above GitHub Codespaces.
 lang: en-GB
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2025-07-24-parameterized-reports-python/index.md
+++ b/content/blog/quarto/2025-07-24-parameterized-reports-python/index.md
@@ -1,23 +1,28 @@
 ---
 people:
   - Charlotte Wickham
-title: 'From One Notebook to Many Reports: Parameterized reports with the `jupyter`
-  engine'
-description: "Learn how to transform a single Jupyter notebook into a parameterized
-  report generator that automatically creates customized outputs for different scenarios.
-  \n"
+title: >-
+  From One Notebook to Many Reports: Parameterized reports with the `jupyter`
+  engine
+description: >
+  Learn how to transform a single Jupyter notebook into a parameterized report
+  generator that automatically creates customized outputs for different
+  scenarios. 
 date: '2025-07-24'
 topics:
   - Publishing
 image: thumbnail.png
-image-alt: |
-  A slide with a screenshot of a Jupyter notebook with a graph and text, then an arrow pointing to a stack of PDF files each with a graph and text.
-lightbox: yes
+image-alt: >
+  A slide with a screenshot of a Jupyter notebook with a graph and text, then an
+  arrow pointing to a stack of PDF files each with a graph and text.
+lightbox: true
 ported_from: quarto
 source: quarto
 port_status: in-progress
-software: ["quarto"]
-languages: ["Python"]
+software:
+  - quarto
+languages:
+  - Python
 ported_categories:
   - Authoring
   - Teaching
@@ -31,10 +36,17 @@ slug: parameterized-reports-python
 ---
 
 
-> **Based on a talk at SciPy 2025**
->
-> This post is based on the talk "From One Notebook to Many Reports: Automating with Quarto" delivered at [SciPy 2025](https://www.scipy2025.scipy.org) by Charlotte Wickham.
-> You can find the slides at [cwickham.github.io/one-notebook-many-reports](https://cwickham.github.io/one-notebook-many-reports/) and example code at [github.com/cwickham/one-notebook-many-reports](https://github.com/cwickham/one-notebook-many-reports).
+<div class="callout callout-tip" role="note" aria-label="Tip">
+<div class="callout-header">
+<span class="callout-title">Based on a talk at SciPy 2025</span>
+</div>
+<div class="callout-body">
+
+This post is based on the talk "From One Notebook to Many Reports: Automating with Quarto" delivered at [SciPy 2025](https://www.scipy2025.scipy.org) by Charlotte Wickham.
+You can find the slides at [cwickham.github.io/one-notebook-many-reports](https://cwickham.github.io/one-notebook-many-reports/) and example code at [github.com/cwickham/one-notebook-many-reports](https://github.com/cwickham/one-notebook-many-reports).
+
+</div>
+</div>
 
 ## The Problem: Repetitive Reporting
 
@@ -65,9 +77,8 @@ You can see the full notebook, [`corvallis.ipynb`, on GitHub](https://github.com
 
 This single notebook can be rendered with Quarto:
 
-**Terminal**
 
-``` bash
+``` bash { filename="Terminal" }
 quarto render corvallis.ipynb 
 ```
 
@@ -92,9 +103,8 @@ We want a report for each city.
 We'll start by creating a variable, `city`, which we'll designate a parameter in our next step.
 In a new code cell at the top of our notebook, we define the variable:
 
-**code**
 
-``` python
+``` python { filename="code" }
 city = "Corvallis"
 ```
 
@@ -103,56 +113,51 @@ Then anywhere we previously hardcoded `"Corvallis"` in the notebook, we replace 
 The first occurrence is in the title of the document.
 Originally, we had a markdown cell defining a level 1 heading:
 
-**markdown**
 
-``` markdown
+``` markdown { filename="markdown" }
 # Corvallis
 ```
 
 We replace it with a code cell that uses an f-string to produce markdown for a level 1 heading based on the `city` variable:
 
-**code**
 
-``` markdown
+``` markdown { filename="code" }
 Markdown(f"# {city}")
 ```
 
 In the filtering step the replacement is straightforward, we just change the string to the variable:
 
-<table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-<p>Before:</p>
-<div class="code-with-filename">
-<strong>code</strong>
-<div class="sourceCode" id="cb1" data-filename="code"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>tmean <span class="op">=</span> tmean_oregon.<span class="bu">filter</span>(</span>
-<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>    pl.col(<span class="st">&quot;city&quot;</span>) <span class="op">==</span> <span class="st">&quot;Corvallis&quot;</span>,</span>
-<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>)</span></code></pre></div>
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
+Before:
+
+
+``` python { filename="code" }
+tmean = tmean_oregon.filter(
+    pl.col("city") == "Corvallis",
+)
+```
+
 </div>
-</div></td>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-<p>After:</p>
-<div class="code-with-filename">
-<strong>code</strong>
-<div class="sourceCode" id="cb2" data-filename="code"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>tmean <span class="op">=</span> tmean_oregon.<span class="bu">filter</span>(</span>
-<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>    pl.col(<span class="st">&quot;city&quot;</span>) <span class="op">==</span> city,</span>
-<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>)</span></code></pre></div>
+<div class="prose max-w-none">
+
+After:
+
+
+``` python { filename="code" }
+tmean = tmean_oregon.filter(
+    pl.col("city") == city,
+)
+```
+
 </div>
-</div></td>
-</tr>
-</tbody>
-</table>
+</div>
 
 Finally, the plot code (using [plotnine](https://plotnine.org)), sets the title of the plot to include the city name:
 
-**code**
 
-``` python
+``` python { filename="code" }
 ...
 + labs(title = "Corvallis, OR", ...)
 ...
@@ -160,9 +165,8 @@ Finally, the plot code (using [plotnine](https://plotnine.org)), sets the title 
 
 We can also use an f-string here to include the `city` variable:
 
-**code**
 
-``` python
+``` python { filename="code" }
 ...
 + labs(title = f"{city}, OR", ...)
 ...
@@ -186,17 +190,15 @@ You can see the updated notebook, now a parameterized notebook, on GitHub: [`cli
 
 If we render `climate.ipynb`, it will still produce the same report for Corvallis, because we haven't changed the parameter value:
 
-**Terminal**
 
-``` bash
+``` bash { filename="Terminal" }
 quarto render climate.ipynb
 ```
 
 But we can now pass parameter values to Quarto with the `-P` flag:
 
-**Terminal**
 
-``` bash
+``` bash { filename="Terminal" }
 # Generate report for Portland
 quarto render climate.ipynb -P city:Portland --output-file portland.pdf
 
@@ -212,9 +214,8 @@ To generate all 50 reports, we need to run `quarto render` 50 times, each time w
 You could automate this in many ways, but let's use a Python script.
 For example, you might have a dataset of cities and their corresponding output filenames:
 
-**gen-reports.py**
 
-``` python
+``` python { filename="gen-reports.py" }
 cities = pl.DataFrame({
     "city": ["Portland", "Cottage Grove", "St. Helens", "Eugene"],
     "output_file": ["portland.pdf", "cottage_grove.pdf", "st_helens.pdf", "eugene.pdf"]
@@ -224,9 +225,8 @@ cities = pl.DataFrame({
 I've generated a small example above, but in reality you would likely read `cities` in from a file.
 Then you could iterate over the rows of this dataset, rendering the notebook for each city:
 
-**gen-reports.py**
 
-``` python
+``` python { filename="gen-reports.py" }
 from quarto import render
 for row in cities.iter_rows(named=True):
     render(
@@ -249,9 +249,8 @@ However, if you are targeting `typst` you can take advantage of additional featu
 
 Quarto supports [brand.yml](https://posit-dev.github.io/brand-yml/) a way to specify colors, fonts, and logos:
 
-**\_brand.yml**
 
-``` yaml
+``` yaml { filename="_brand.yml" }
 color:
   palette:
     forest-green: "#2d5a3d"     

--- a/content/blog/quarto/2025-07-24-parameterized-reports-python/index.qmd
+++ b/content/blog/quarto/2025-07-24-parameterized-reports-python/index.qmd
@@ -7,13 +7,14 @@ description: "Learn how to transform a single Jupyter notebook into a parameteri
   report generator that automatically creates customized outputs for different scenarios.
   \n"
 date: '2025-07-24'
-categories:
+topics:
   - Publishing
 image: thumbnail.png
 image-alt: |
   A slide with a screenshot of a Jupyter notebook with a graph and text, then an arrow pointing to a stack of PDF files each with a graph and text.
-lightbox: yes
+lightbox: true
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["Python"]

--- a/content/blog/quarto/2025-07-28-R-package-release-1.5/index.qmd
+++ b/content/blog/quarto/2025-07-28-R-package-release-1.5/index.qmd
@@ -2,7 +2,7 @@
 title: 'quarto R package v1.5.0: Streamlined Workflows for R Users'
 description: |
   The quarto R package 1.5.0 brings powerful new features for passing R values to Quarto metadata, inserting Markdown in HTML tables, working with R scripts, building paths from Quarto projects, and automating Quarto CLI from R.
-categories:
+topics:
   - Publishing
 people:
   - Christophe Dervieux
@@ -10,6 +10,7 @@ date: '2025-07-28'
 image: thumbnail.png
 image-alt: quarto R logo with 1.5.0 release text
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R"]

--- a/content/blog/quarto/2025-10-13-1.8-release/index.qmd
+++ b/content/blog/quarto/2025-10-13-1.8-release/index.qmd
@@ -2,7 +2,7 @@
 title: Quarto 1.8
 description: |
   Quarto 1.8 improves brand support, introduces brand extensions, adds HTML accessibility checks, and gives access to execution context.
-categories:
+topics:
   - Publishing
 people:
   - Charlotte Wickham
@@ -12,6 +12,7 @@ image: thumbnail.png
 image-alt: Quarto 1.8 with a lightbulb emoji
 css: /docs/output-formats/autodark.css
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2025-10-20-quarto-wizard-1-0-0/index.md
+++ b/content/blog/quarto/2025-10-20-quarto-wizard-1-0-0/index.md
@@ -138,68 +138,66 @@ If you've ever found yourself wrestling with command-line extension management o
 
 Install it today from the [VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=mcanouil.quarto-wizard) or [Open VSX Registry](https://open-vsx.org/extension/mcanouil/quarto-wizard):
 
-<table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-<ul>
-<li><p>Via VS Code or Positron Extensions view:</p>
-<ul>
-<li>Search for “Quarto Wizard”.</li>
-<li>Click “Install”.</li>
-</ul>
-<p>
-<img src="assets/media/extensions-marketplace-light.png" title="Extensions View: Marketplace" class="light-content img-thumbnail rounded-3 border-light" data-fig-align="center" data-group="quarto-wizard-light" data-fig-alt="Visual Studio Code Extensions Marketplace showing Quarto Wizard search
-results with install button.
-" width="500" /></p></li>
-</ul>
-</div></td>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-<ul>
-<li><p>Via the command line:</p>
-<div class="panel-tabset">
-<ul id="tabset-1" class="panel-tabset-tabby">
-<li><a data-tabby-default href="#tabset-1-1">Visual Studio Code</a></li>
-<li><a href="#tabset-1-2">Positron</a></li>
-</ul>
-<div id="tabset-1-1">
-<div class="code-with-filename">
-<strong>Terminal</strong>
-<div class="sourceCode" id="cb1" data-filename="Terminal"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">code</span> <span class="at">--install-extension</span> mcanouil.quarto-wizard</span></code></pre></div>
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
+- Via VS Code or Positron Extensions view:
+
+  - Search for "Quarto Wizard".
+  - Click "Install".
+
+  <img src="assets/media/extensions-marketplace-light.png" title="Extensions View: Marketplace" class="light-content img-thumbnail rounded-3 border-light" data-fig-align="center" data-group="quarto-wizard-light" data-fig-alt="Visual Studio Code Extensions Marketplace showing Quarto Wizard search
+  results with install button.
+  " width="500" />
+
 </div>
-<div class="callout callout-tip" role="note" aria-label="Tip">
-<div class="callout-header">
-<span class="callout-title">Tip</span>
+<div class="prose max-w-none">
+
+- Via the command line:
+
+  <div class="panel-tabset">
+  <ul id="tabset-1" class="panel-tabset-tabby">
+  <li><a data-tabby-default href="#tabset-1-1">Visual Studio Code</a></li>
+  <li><a href="#tabset-1-2">Positron</a></li>
+  </ul>
+  <div id="tabset-1-1">
+
+  ``` bash { filename="Terminal" }
+  code --install-extension mcanouil.quarto-wizard
+  ```
+
+  <div class="callout callout-tip" role="note" aria-label="Tip">
+  <div class="callout-header">
+  <span class="callout-title">Tip</span>
+  </div>
+  <div class="callout-body">
+
+  Be sure to execute the command *Shell Command: Install 'code' command in PATH* from Visual Studio Code's Command Palette (`Cmd-Shift-P` (mac), `Ctrl-Shift-P` (windows), `Ctrl-Shift-P` (linux)) if you haven't done so already.
+
+  </div>
+  </div>
+  </div>
+  <div id="tabset-1-2">
+
+  ``` bash { filename="Terminal" }
+  positron --install-extension mcanouil.quarto-wizard
+  ```
+
+  <div class="callout callout-tip" role="note" aria-label="Tip">
+  <div class="callout-header">
+  <span class="callout-title">Tip</span>
+  </div>
+  <div class="callout-body">
+
+  Be sure to execute the command *Shell Command: Install 'positron' command in PATH* from Positron's Command Palette (`Cmd-Shift-P` (mac), `Ctrl-Shift-P` (windows), `Ctrl-Shift-P` (linux)) if you haven't done so already.
+
+  </div>
+  </div>
+  </div>
+  </div>
+
 </div>
-<div class="callout-body">
-<p>Be sure to execute the command <em>Shell Command: Install ‘code’ command in PATH</em> from Visual Studio Code’s Command Palette (<code>Cmd-Shift-P</code> (mac), <code>Ctrl-Shift-P</code> (windows), <code>Ctrl-Shift-P</code> (linux)) if you haven’t done so already.</p>
 </div>
-</div>
-</div>
-<div id="tabset-1-2">
-<div class="code-with-filename">
-<strong>Terminal</strong>
-<div class="sourceCode" id="cb2" data-filename="Terminal"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">positron</span> <span class="at">--install-extension</span> mcanouil.quarto-wizard</span></code></pre></div>
-</div>
-<div class="callout callout-tip" role="note" aria-label="Tip">
-<div class="callout-header">
-<span class="callout-title">Tip</span>
-</div>
-<div class="callout-body">
-<p>Be sure to execute the command <em>Shell Command: Install ‘positron’ command in PATH</em> from Positron’s Command Palette (<code>Cmd-Shift-P</code> (mac), <code>Ctrl-Shift-P</code> (windows), <code>Ctrl-Shift-P</code> (linux)) if you haven’t done so already.</p>
-</div>
-</div>
-</div>
-</div></li>
-</ul>
-</div></td>
-</tr>
-</tbody>
-</table>
 
 Quarto has revolutionised scientific and technical publishing by enabling reproducible documents that seamlessly blend code, narrative text, and visualisation.
 However, one persistent friction point has been managing the rich and ever-growing ecosystem of extensions and templates---until now.
@@ -219,31 +217,16 @@ no extensions installed message with green Install Extensions button.
 
 The solution is **multi-modal installation**: you can now install extensions through multiple pathways that suit your workflow: from the command line, through the web directory, or via the **Quarto Wizard** GUI in your IDE.
 
-<table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-<ol type="1">
-<li>Open the Command Palette (<code>Cmd-Shift-P</code> (mac), <code>Ctrl-Shift-P</code> (windows), <code>Ctrl-Shift-P</code> (linux)).</li>
-<li>Type <code>Quarto Wizard: Install Extensions</code> and select it.</li>
-<li>Browse the list of available Quarto extensions.</li>
-<li>Select the Quarto extension(s) you want to install.</li>
-<li>Answer the prompts to confirm the installation.</li>
-</ol>
-</div></td>
-<td style="text-align: center;"><div width="50.0%" data-layout-align="center">
-<p><img src="assets/media/vscode-install-light.png" title="Quarto Wizard: Install Extensions (Light)" class="light-content img-thumbnail rounded-3 border-light" data-fig-align="center" data-group="quarto-wizard-light" data-fig-alt="Quarto Wizard extension selection dialog showing list of available
+<div class="grid gap-12 items-center md:grid-cols-2">
+<div class="prose max-w-none">
+
+<img src="assets/media/vscode-install-light.png" title="Quarto Wizard: Install Extensions (Light)" class="light-content img-thumbnail rounded-3 border-light" data-fig-align="center" data-group="quarto-wizard-light" data-fig-alt="Quarto Wizard extension selection dialog showing list of available
 extensions with checkboxes including LIVE, HIGHLIGHT TEXT, GITHUB, and
 other Quarto extensions.
-" width="500" /></p>
-</div></td>
-</tr>
-</tbody>
-</table>
+" width="500" />
+
+</div>
+</div>
 
 ### Intelligent extension management
 
@@ -265,30 +248,15 @@ Beyond extension management, I've designed **Quarto Wizard** to ease the process
 Once you've selected a template, **Quarto Wizard** lets you customise and save the document.
 The file is not created until you confirm, allowing you to adjust the filename and location.
 
-<table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-<ol type="1">
-<li>Open the Command Palette (<code>Cmd-Shift-P</code> (mac), <code>Ctrl-Shift-P</code> (windows), <code>Ctrl-Shift-P</code> (linux)).</li>
-<li>Type <code>Quarto Wizard: Use Template</code> and select it.</li>
-<li>Browse the list of available Quarto templates.</li>
-<li>Select the Quarto template(s) you want to use.</li>
-<li>Answer the prompts to confirm the selection.</li>
-</ol>
-</div></td>
-<td style="text-align: center;"><div width="50.0%" data-layout-align="center">
-<p><img src="assets/media/vscode-template-light.png" title="Quarto Wizard: Use Template (Light)" class="light-content img-thumbnail rounded-3 border-light" data-fig-align="center" data-group="quarto-wizard-light" data-fig-alt="Visual Studio Code showing Quarto Wizard with installed extensions list
+<div class="grid gap-12 items-center md:grid-cols-2">
+<div class="prose max-w-none">
+
+<img src="assets/media/vscode-template-light.png" title="Quarto Wizard: Use Template (Light)" class="light-content img-thumbnail rounded-3 border-light" data-fig-align="center" data-group="quarto-wizard-light" data-fig-alt="Visual Studio Code showing Quarto Wizard with installed extensions list
 and document editor displaying invoice template with YAML frontmatter.
-" width="500" /></p>
-</div></td>
-</tr>
-</tbody>
-</table>
+" width="500" />
+
+</div>
+</div>
 
 ## Powered by a comprehensive extension directory
 

--- a/content/blog/quarto/2025-10-20-quarto-wizard-1-0-0/index.md
+++ b/content/blog/quarto/2025-10-20-quarto-wizard-1-0-0/index.md
@@ -172,7 +172,7 @@ Install it today from the [VS Code marketplace](https://marketplace.visualstudio
   </div>
   <div class="callout-body">
 
-  Be sure to execute the command *Shell Command: Install 'code' command in PATH* from Visual Studio Code's Command Palette (`Cmd-Shift-P` (mac), `Ctrl-Shift-P` (windows), `Ctrl-Shift-P` (linux)) if you haven't done so already.
+  Be sure to execute the command *Shell Command: Install 'code' command in PATH* from Visual Studio Code's Command Palette (`Cmd-Shift-P` (mac), `Ctrl-Shift-P` (linux), `Ctrl-Shift-P` (windows)) if you haven't done so already.
 
   </div>
   </div>
@@ -189,7 +189,7 @@ Install it today from the [VS Code marketplace](https://marketplace.visualstudio
   </div>
   <div class="callout-body">
 
-  Be sure to execute the command *Shell Command: Install 'positron' command in PATH* from Positron's Command Palette (`Cmd-Shift-P` (mac), `Ctrl-Shift-P` (windows), `Ctrl-Shift-P` (linux)) if you haven't done so already.
+  Be sure to execute the command *Shell Command: Install 'positron' command in PATH* from Positron's Command Palette (`Cmd-Shift-P` (mac), `Ctrl-Shift-P` (linux), `Ctrl-Shift-P` (windows)) if you haven't done so already.
 
   </div>
   </div>

--- a/content/blog/quarto/2025-10-20-quarto-wizard-1-0-0/index.qmd
+++ b/content/blog/quarto/2025-10-20-quarto-wizard-1-0-0/index.qmd
@@ -9,7 +9,7 @@ title: 'Quarto Wizard 1.0.0: Democratising Quarto Extension Management'
 description: |
   Introducing a game-changing extension for VS Code and Positron that transforms Quarto extensions management with an intuitive GUI for extensions and templates.
 date: '2025-10-20'
-categories:
+topics:
   - Publishing
 image: featured.png
 image-alt: Cartoon dog wizard wearing blue hat with red band holding magic wand creating
@@ -60,6 +60,7 @@ alt-text:
 editor:
   render-on-save: true
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto", "positron"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2025-10-27-conf-workshops-materials/index.qmd
+++ b/content/blog/quarto/2025-10-27-conf-workshops-materials/index.qmd
@@ -2,7 +2,7 @@
 title: posit::conf(2025) Quarto workshop materials
 description: |
   At posit::conf(2025) we hosted two Quarto workshops: Branded Websites, Presentations, Dashboards, and PDFs with Quarto; and Extending Quarto. The materials from both workshops are freely available for anyone to learn from or use in their own teaching.
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -11,6 +11,7 @@ date: '2025-10-27'
 image: thumbnail.png
 image-alt: Quarto workshop materials @ posit::conf(2025)
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2025-11-24-conf-talk-videos/index.qmd
+++ b/content/blog/quarto/2025-11-24-conf-talk-videos/index.qmd
@@ -2,7 +2,7 @@
 title: posit::conf(2025) Quarto talks
 description: |
   Videos of talks from posit::conf(2025) are posted, and you can find them all here!
-categories:
+topics:
   - Publishing
   - Community
 people:
@@ -11,6 +11,7 @@ date: '2025-11-24'
 image: thumbnail.png
 image-alt: Talk Recordings at posit::conf(2025)
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]

--- a/content/blog/quarto/2026-03-05-pdf-accessibility-and-standards/index.md
+++ b/content/blog/quarto/2026-03-05-pdf-accessibility-and-standards/index.md
@@ -55,28 +55,30 @@ Both standards instruct the PDF renderer to provide screen readers:
 
 In Quarto 1.9, specify a PDF standard for your document or project with `pdf-standard`
 
-<table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-<p><strong>PDF (LaTeX)</strong></p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">format</span><span class="kw">:</span></span>
-<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">pdf</span><span class="kw">:</span></span>
-<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">pdf-standard</span><span class="kw">:</span><span class="at"> ua-2</span></span></code></pre></div>
-</div></td>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-<p><strong>Typst</strong></p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">format</span><span class="kw">:</span></span>
-<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">typst</span><span class="kw">:</span></span>
-<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">pdf-standard</span><span class="kw">:</span><span class="at"> ua-1</span></span></code></pre></div>
-</div></td>
-</tr>
-</tbody>
-</table>
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
+**PDF (LaTeX)**
+
+``` yaml
+format:
+  pdf:
+    pdf-standard: ua-2
+```
+
+</div>
+<div class="prose max-w-none">
+
+**Typst**
+
+``` yaml
+format:
+  typst:
+    pdf-standard: ua-1
+```
+
+</div>
+</div>
 
 `pdf-standard` takes a single standard name or list of standard names. PDF version is used if provided in the list, but otherwise inferred from the standard.
 

--- a/content/blog/quarto/2026-03-05-pdf-accessibility-and-standards/index.qmd
+++ b/content/blog/quarto/2026-03-05-pdf-accessibility-and-standards/index.qmd
@@ -8,10 +8,11 @@ date: '2026-03-05'
 image: thumbnail.png
 image-alt: Quarto icon, PDF file icon, accessibility icon, and validation shield
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software: ["quarto"]
 languages: ["R", "Python", "Julia"]
-categories:
+topics:
   - Publishing
 tags:
   - Quarto

--- a/content/blog/quarto/2026-03-24-1.9-release/index.md
+++ b/content/blog/quarto/2026-03-24-1.9-release/index.md
@@ -100,33 +100,32 @@ See [Guide \> Brand](https://quarto.org/docs/authoring/brand.html#quarto-use-bra
 
 List tables provide a new syntax for creating tables with complex content---multiple paragraphs, code blocks, or nested lists---using familiar bullet syntax instead of grid table formatting:
 
-<table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="50.0%" data-layout-align="left">
-<div class="sourceCode" id="cb1"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>::: {.list-table}</span>
-<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>- Function</span>
-<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="ss">  - </span>Description</span>
-<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>- <span class="in">`sum()`</span></span>
-<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="ss">  - </span>Add values:</span>
-<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a>    <span class="in">```python</span></span>
-<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a>    <span class="bu">sum</span>([<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>])</span>
-<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a>    <span class="in">```</span></span>
-<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a><span class="ss">- </span>- <span class="in">`len()`</span></span>
-<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a><span class="ss">  - </span>Count items:</span>
-<span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a><span class="ss">    - </span>Works on lists</span>
-<span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a><span class="ss">    - </span>Works on strings</span>
-<span id="cb1-17"><a href="#cb1-17" aria-hidden="true" tabindex="-1"></a>:::</span></code></pre></div>
-</div></td>
-<td style="text-align: center;"><div width="50.0%" data-layout-align="center">
+<div class="grid gap-12 items-start md:grid-cols-2">
+<div class="prose max-w-none">
+
+```` markdown
+::: {.list-table}
+- - Function
+  - Description
+
+- - `sum()`
+  - Add values:
+
+    ```python
+    sum([1, 2, 3])
+    ```
+
+- - `len()`
+  - Count items:
+
+    - Works on lists
+    - Works on strings
+:::
+````
+
+</div>
+<div class="prose max-w-none">
+
 <table>
 <thead>
 <tr>
@@ -138,7 +137,7 @@ List tables provide a new syntax for creating tables with complex content---mult
 <tr>
 <td><p><code>sum()</code></p></td>
 <td><p>Add values:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="bu">sum</span>([<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>])</span></code></pre></div></td>
+<div class="sourceCode" id="cb1"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="bu">sum</span>([<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>])</span></code></pre></div></td>
 </tr>
 <tr>
 <td><p><code>len()</code></p></td>
@@ -150,10 +149,9 @@ List tables provide a new syntax for creating tables with complex content---mult
 </tr>
 </tbody>
 </table>
-</div></td>
-</tr>
-</tbody>
-</table>
+
+</div>
+</div>
 
 Each top-level bullet represents a row; nested bullets represent cells. This syntax is much easier to maintain than grid tables, especially when cells contain code or other block elements.
 

--- a/content/blog/quarto/2026-03-24-1.9-release/index.qmd
+++ b/content/blog/quarto/2026-03-24-1.9-release/index.qmd
@@ -8,13 +8,14 @@ date: "2026-03-24"
 image: thumbnail.png
 image-alt: "Quarto 1.9"
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software:
   - quarto
 languages:
   - R
   - Python
-categories:
+topics:
   - Publishing
 tags:
   - Quarto

--- a/content/blog/quarto/2026-03-31-typst-books-and-more/index.md
+++ b/content/blog/quarto/2026-03-31-typst-books-and-more/index.md
@@ -55,42 +55,40 @@ book:
 format: typst
 ```
 
-<table>
-<colgroup>
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+<div class="grid gap-12 items-start md:grid-cols-4">
+<div class="prose max-w-none">
+
 <figure>
 <img src="typst-book-part-page.png" data-fig-alt="A Typst book rendered with the orange-book extension, showing the part one page with a colored background and table of contents" alt="Part page" />
 <figcaption aria-hidden="true">Part page</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="typst-book-1.png" data-fig-alt="A Typst book rendered with the orange-book extension, showing the chapter one page with colored headers and sidebar navigation" alt="Chapter page" />
 <figcaption aria-hidden="true">Chapter page</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="typst-book-2.png" data-fig-alt="A Typst book rendered with the orange-book extension, showing the second page from chapter one with colored headers and sidebar navigation" alt="Chapter content" />
 <figcaption aria-hidden="true">Chapter content</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="25.0%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="typst-book-3.png" data-fig-alt="A Typst book rendered with the orange-book extension, showing the chapter two page with colored headers and sidebar navigation" alt="Next chapter" />
 <figcaption aria-hidden="true">Next chapter</figcaption>
 </figure>
-</div></td>
-</tr>
-</tbody>
-</table>
+
+</div>
+</div>
 
 All book features previously available in the LaTeX format are now available in Typst:
 
@@ -133,36 +131,32 @@ Specifically:
 - Footnotes and citations can be displayed in the margin with `reference-location: margin` and `citation-location: margin`. When margin citations are enabled, the bibliography is suppressed.
 - Asides (`.aside` class) place content in the margin without a footnote number.
 
-<table style="width:100%;">
-<colgroup>
-<col style="width: 33%" />
-<col style="width: 33%" />
-<col style="width: 33%" />
-</colgroup>
-<tbody>
-<tr>
-<td style="text-align: left;"><div width="33.3%" data-layout-align="left">
+<div class="grid gap-12 items-start md:grid-cols-3">
+<div class="prose max-w-none">
+
 <figure>
 <img src="typst-article.png" data-group="article" data-fig-alt="A page of a Typst article with a margin note and a margin figure using the Marginalia package" alt="Margin note and figure" />
 <figcaption aria-hidden="true">Margin note and figure</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="33.3%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="typst-article-2.png" data-group="article" data-fig-alt="A page of a Typst article using margin captions" alt="Margin captions" />
 <figcaption aria-hidden="true">Margin captions</figcaption>
 </figure>
-</div></td>
-<td style="text-align: left;"><div width="33.3%" data-layout-align="left">
+
+</div>
+<div class="prose max-w-none">
+
 <figure>
 <img src="typst-article-3.png" data-group="article" data-fig-alt="A page of a Typst article using margin references" alt="Margin references" />
 <figcaption aria-hidden="true">Margin references</figcaption>
 </figure>
-</div></td>
-</tr>
-</tbody>
-</table>
 
+</div>
+</div>
 <div class="callout callout-warning" role="note" aria-label="Warning">
 <div class="callout-header">
 <span class="callout-title">Books with article layout are functional, but need work</span>

--- a/content/blog/quarto/2026-03-31-typst-books-and-more/index.qmd
+++ b/content/blog/quarto/2026-03-31-typst-books-and-more/index.qmd
@@ -9,13 +9,14 @@ image: typst-article-landscape.png
 image-alt: A Typst article page showing code and a margin figure rendered with the Marginalia package
 lightbox: true
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software:
   - quarto
 languages:
   - R
   - Python
-categories:
+topics:
   - Publishing
 tags:
   - Quarto

--- a/content/blog/quarto/2026-04-06-whats-next-quarto-2/index.qmd
+++ b/content/blog/quarto/2026-04-06-whats-next-quarto-2/index.qmd
@@ -8,13 +8,14 @@ image-alt: "Quarto 2.0"
 description: |
   We've started working on [`quarto-dev/q2`](https://github.com/quarto-dev/q2/), a full rewrite of Quarto in Rust.
 ported_from: quarto
+source: quarto
 port_status: in-progress
 software:
   - quarto
 languages:
   - R
   - Python
-categories:
+topics:
   - Publishing
 tags:
   - Quarto

--- a/content/blog/shiny/announcing-new-r-shiny-ui-components/index.qmd
+++ b/content/blog/shiny/announcing-new-r-shiny-ui-components/index.qmd
@@ -8,10 +8,11 @@ date: '2022-12-20'
 image: bslib.jpg
 image-alt: A picture of Bob Ross
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["bslib", "shiny-r"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/bslib-0.9.0/index.qmd
+++ b/content/blog/shiny/bslib-0.9.0/index.qmd
@@ -7,10 +7,11 @@ date: '2025-01-31'
 image: feature.jpg
 image-alt: bslib + brand.yml
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["bslib", "shiny-r", "brand-yml"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/bslib-dashboards/index.qmd
+++ b/content/blog/shiny/bslib-dashboards/index.qmd
@@ -7,10 +7,11 @@ people:
 date: '2023-06-07'
 image: feature.png
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["bslib", "shiny-r"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/bslib-tooltips/index.qmd
+++ b/content/blog/shiny/bslib-tooltips/index.qmd
@@ -8,10 +8,11 @@ people:
 date: '2023-08-16'
 image: feature.png
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["bslib", "shiny-r"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/cards-in-shinyuieditor/index.qmd
+++ b/content/blog/shiny/cards-in-shinyuieditor/index.qmd
@@ -14,10 +14,11 @@ resources:
   - add-footer-to-card.webm
   - add-plot-to-card.webm
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shinyuieditor", "bslib", "shiny-r"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/chromote-0.5.0/index.qmd
+++ b/content/blog/shiny/chromote-0.5.0/index.qmd
@@ -9,10 +9,11 @@ date: '2025-03-21'
 image: feature.png
 image-alt: chromote v0.5.0
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["chromote"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/conf-2023-recap-andrew-holz/index.qmd
+++ b/content/blog/shiny/conf-2023-recap-andrew-holz/index.qmd
@@ -8,10 +8,11 @@ date: '2023-03-28'
 image: shinyconflogo.jpg
 image-alt: The Shiny Conf Logo on a dark blue background
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-r", "bslib"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/conf-2024-shinytalks/index.qmd
+++ b/content/blog/shiny/conf-2024-shinytalks/index.qmd
@@ -9,10 +9,11 @@ image-header-disable: yes
 image: shinytalks.jpg
 image-alt: Collage of speakers with Shiny talks at posit::conf(2024)
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-r", "shiny-python"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/conf-2025-shinytalks/index.qmd
+++ b/content/blog/shiny/conf-2025-shinytalks/index.qmd
@@ -8,10 +8,11 @@ image-header-disable: yes
 image: conf-recordings-banner.png
 image-alt: Shiny talks and workshops at posit::conf(2025)
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-r", "shiny-python"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/dynamic-accordion-panels/index.qmd
+++ b/content/blog/shiny/dynamic-accordion-panels/index.qmd
@@ -6,10 +6,11 @@ people:
 date: '2025-02-05'
 image: forms.jpg
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/introducing-component-layouts/index.qmd
+++ b/content/blog/shiny/introducing-component-layouts/index.qmd
@@ -10,10 +10,11 @@ date: '2024-02-26'
 image: layouts-thumb.jpg
 image-alt: An illustration of Shiny layouts and components
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/introducing-shiny-templates/index.qmd
+++ b/content/blog/shiny/introducing-shiny-templates/index.qmd
@@ -7,10 +7,11 @@ date: '2024-04-05'
 image: templates2.jpg
 image-alt: An illustration of a Shiny Template
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python", "py-shiny-templates"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/promises-1.5.0/index.qmd
+++ b/content/blog/shiny/promises-1.5.0/index.qmd
@@ -12,10 +12,11 @@ editor:
   markdown:
     wrap: sentence
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["promises"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/querychat-python-r/index.qmd
+++ b/content/blog/shiny/querychat-python-r/index.qmd
@@ -8,10 +8,11 @@ date: '2026-01-22'
 image: querychat-python-r-header.png
 image-alt: 'Where Questions Become Queries: Meet querychat'
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["querychat", "shiny-python", "shiny-r", "chatlas", "ellmer"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/responsive-shiny-layouts/index.qmd
+++ b/content/blog/shiny/responsive-shiny-layouts/index.qmd
@@ -7,10 +7,11 @@ people:
 date: '2025-02-08'
 image: shiny-layouts.jpg
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python", "bslib"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-assistant/index.qmd
+++ b/content/blog/shiny/shiny-assistant/index.qmd
@@ -8,10 +8,11 @@ image-alt: an image with lines representing ai computing lie behind a chatbox ic
 image-video: shiny-assistant.mp4
 image: shiny-assistant.gif
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-assistant", "shiny-python", "shiny-r"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-at-conf-2025/index.qmd
+++ b/content/blog/shiny/shiny-at-conf-2025/index.qmd
@@ -13,10 +13,11 @@ listing:
     template: talks.ejs
     contents: talks.yml
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python", "shiny-r"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-at-scipy-2025/index.qmd
+++ b/content/blog/shiny/shiny-at-scipy-2025/index.qmd
@@ -14,10 +14,11 @@ listing:
     template: talks.ejs
     contents: talks.yml
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-express/index.qmd
+++ b/content/blog/shiny/shiny-express/index.qmd
@@ -7,10 +7,11 @@ date: '2024-01-29'
 image: shiny-express-v2.jpg
 image-alt: Shiny Express logo
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-on-hugging-face/index.qmd
+++ b/content/blog/shiny/shiny-on-hugging-face/index.qmd
@@ -7,10 +7,11 @@ date: '2023-05-08'
 image: shiny-on-hf-thumb.jpg
 image-alt: The Shiny hex next to the Hugging Face emoji logo
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python", "shiny-r"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-0.4.0/index.qmd
+++ b/content/blog/shiny/shiny-python-0.4.0/index.qmd
@@ -7,10 +7,11 @@ date: '2023-06-28'
 image: shiny-040.png
 image-alt: Shiny for Python 0.4.0
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-0.5.0/index.qmd
+++ b/content/blog/shiny/shiny-python-0.5.0/index.qmd
@@ -8,10 +8,11 @@ date: '2023-08-09'
 image: shiny-050.png
 image-alt: Shiny for Python 0.5.0
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-0.6.0/index.md
+++ b/content/blog/shiny/shiny-python-0.6.0/index.md
@@ -48,6 +48,9 @@ The updated layout sidebar (`ui.layout_sidebar()`) no longer needs to include a 
 
 ### Sidebars
 
+<div class="grid gap-12 items-start md:grid-cols-[45fr_10fr_45fr] column-page-inset">
+<div class="prose max-w-none">
+
 #### Old API
 
 ``` python
@@ -63,6 +66,11 @@ ui.page_fluid(
 )
 ```
 
+</div>
+<div class="prose max-w-none">
+</div>
+<div class="prose max-w-none">
+
 #### New API
 
 ``` python
@@ -75,6 +83,9 @@ ui.page_sidebar(
     ),
 )
 ```
+
+</div>
+</div>
 
 In addition to `sidebar`, we have added `ui.page_fillable()` to help users create applications that fill the available space in the window. This is great for applications where the plot should fill the entire contents fo the window. `ui.page_sidebar()` is a wrapper around `ui.page_fillable()`. In addition to the filling layout method, many UI output methods have added `fill=` or `fillable=` parameters to allow for the component to fill the available area (`fill=True`) or to allow for contained components to fill the available content area (`fillable=`). The handshake of `fill=True` and `fillable=True` must occur to achieve a filling layout. Let's take a look at the new layout in action:
 

--- a/content/blog/shiny/shiny-python-0.6.0/index.qmd
+++ b/content/blog/shiny/shiny-python-0.6.0/index.qmd
@@ -7,10 +7,11 @@ date: '2023-11-15'
 image: shiny-060.png
 image-alt: Shiny for Python 0.6.0
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-0.6.1/index.qmd
+++ b/content/blog/shiny/shiny-python-0.6.1/index.qmd
@@ -9,10 +9,11 @@ image-alt: Shiny for Python 0.6.1
 resources:
   - shiny-061.png
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-0.9.0/index.qmd
+++ b/content/blog/shiny/shiny-python-0.9.0/index.qmd
@@ -16,10 +16,11 @@ resources:
   - shiny-template.png
   - quarto-and-shiny-express.png
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-1.0/index.qmd
+++ b/content/blog/shiny/shiny-python-1.0/index.qmd
@@ -9,10 +9,11 @@ image-video: shinyforpython-1.0.mp4
 image: shinyforpython-1.0.jpg
 image-alt: Announcing Shiny for Python 1.0
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-1.2-brand-yml/index.qmd
+++ b/content/blog/shiny/shiny-python-1.2-brand-yml/index.qmd
@@ -8,10 +8,11 @@ image: brand-yml-feature.svg
 image-alt: brand.yml logo
 image-header-disable: yes
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python", "brand-yml"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-1.2/index.qmd
+++ b/content/blog/shiny/shiny-python-1.2/index.qmd
@@ -8,10 +8,11 @@ date: '2024-10-31'
 image: shinyforpython-120.jpg
 image-alt: Shiny for Python 1.2.0
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-1.4/index.qmd
+++ b/content/blog/shiny/shiny-python-1.4/index.qmd
@@ -10,10 +10,11 @@ image-alt: Shiny 1.4 brings bookmarking and Generative AI docs
 lightbox:
   effect: fade
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-1.6/index.qmd
+++ b/content/blog/shiny/shiny-python-1.6/index.qmd
@@ -10,10 +10,11 @@ image-alt: "Shiny for Python 1.6 brings toolbars and OpenTelemetry"
 lightbox:
   effect: fade
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-chatstream/index.qmd
+++ b/content/blog/shiny/shiny-python-chatstream/index.qmd
@@ -7,10 +7,11 @@ date: '2023-05-12'
 image: shiny-ai-chatbot.jpg
 image-alt: an image with lines representing ai computing lie behind a chatbox icon
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python", "chatlas"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-general-availability/index.qmd
+++ b/content/blog/shiny/shiny-python-general-availability/index.qmd
@@ -8,10 +8,11 @@ image: shiny-for-python.jpg
 image-alt: The Shiny hex sticker next to the Python language logo, saying Shiny for
   Python
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-python-testing/index.qmd
+++ b/content/blog/shiny/shiny-python-testing/index.qmd
@@ -8,10 +8,11 @@ people:
 date: '2024-10-29'
 image: testing-og.jpg
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-r-1.12/index.qmd
+++ b/content/blog/shiny/shiny-r-1.12/index.qmd
@@ -13,10 +13,11 @@ editor:
   render-on-save: true
 code-annotations: hover
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-r"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-r-1.8.0/index.qmd
+++ b/content/blog/shiny/shiny-r-1.8.0/index.qmd
@@ -8,10 +8,11 @@ people:
 date: '2023-11-30'
 image: feature.jpg
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-r", "shinylive", "bslib"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-r-1.8.1/index.qmd
+++ b/content/blog/shiny/shiny-r-1.8.1/index.qmd
@@ -7,10 +7,11 @@ people:
 date: '2024-03-27'
 image: feature.png
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-r", "bslib"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-side-of-llms-part-1/index.qmd
+++ b/content/blog/shiny/shiny-side-of-llms-part-1/index.qmd
@@ -18,10 +18,11 @@ resources:
   - shiny-side-of-llms-code-gen.png
   - shiny-side-of-llms-image-gen.png
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python", "shiny-r", "chatlas", "ellmer"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-side-of-llms-part-2/index.qmd
+++ b/content/blog/shiny/shiny-side-of-llms-part-2/index.qmd
@@ -8,10 +8,11 @@ date: '2025-09-05'
 image: shiny-side-of-llms-header.png
 image-alt: The Shiny Side of LLMs part 2
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python", "shiny-r", "chatlas", "ellmer"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-side-of-llms-part-3/index.qmd
+++ b/content/blog/shiny/shiny-side-of-llms-part-3/index.qmd
@@ -8,10 +8,11 @@ date: '2025-09-15'
 image: shiny-side-of-llms-header.png
 image-alt: The Shiny Side of LLMs part 3
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python", "shiny-r", "chatlas", "ellmer"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shiny-vscode-1.0.0/index.qmd
+++ b/content/blog/shiny/shiny-vscode-1.0.0/index.qmd
@@ -9,10 +9,11 @@ date: '2024-05-22'
 image: feature.png
 engine: markdown
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-vscode", "shiny-python", "shiny-r"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shinychat-tool-ui/index.qmd
+++ b/content/blog/shiny/shinychat-tool-ui/index.qmd
@@ -8,10 +8,11 @@ people:
 date: '2025-11-20'
 image: feature.png
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shinychat", "shiny-python"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shinyswatch-0.7.0/index.qmd
+++ b/content/blog/shiny/shinyswatch-0.7.0/index.qmd
@@ -7,10 +7,11 @@ people:
 date: '2024-07-19'
 image: feature.jpg
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["py-shinyswatch"]
 languages: ["Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/shinyuieditor-out-of-alpha/index.qmd
+++ b/content/blog/shiny/shinyuieditor-out-of-alpha/index.qmd
@@ -11,10 +11,11 @@ resources:
   - render-function-cleanup-small.mp4
   - synced-ids-small.mp4
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shinyuieditor", "shiny-r"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/the-past-and-future-of-shiny-joe-cheng/index.qmd
+++ b/content/blog/shiny/the-past-and-future-of-shiny-joe-cheng/index.qmd
@@ -8,10 +8,11 @@ date: '2022-12-15'
 image: history-of-shiny.jpg
 image-alt: Joe Cheng speaking at RStudio's conference in 2022
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-python", "shiny-r"]
 languages: ["R", "Python"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/weather-lookup-about/index.qmd
+++ b/content/blog/shiny/weather-lookup-about/index.qmd
@@ -10,10 +10,11 @@ image-alt: A screenshot of Nick Strayer's Weather Lookup Shiny app, which shows 
 resources:
   - previous_city_button.mp4
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-r"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/weather-lookup-bslib/index.qmd
+++ b/content/blog/shiny/weather-lookup-bslib/index.qmd
@@ -9,10 +9,11 @@ date: '2021-04-27'
 image: bslib.jpg
 image-alt: A screenshot of an app, showing it in light mode and dark mode
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-r", "bslib"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny

--- a/content/blog/shiny/weather-lookup-caching/index.qmd
+++ b/content/blog/shiny/weather-lookup-caching/index.qmd
@@ -11,10 +11,11 @@ resources:
   - no_caching_performance.mp4
   - speed_comparison.mp4
 ported_from: shiny
+source: shiny
 port_status: in-progress
 software: ["shiny-r"]
 languages: ["R"]
-categories:
+topics:
   - Interactive Apps
 tags:
   - Shiny


### PR DESCRIPTION
Closes https://github.com/posit-dev/open-source-website/issues/133

## Summary

- Adds `content/_extensions/layout/layout.lua` — a Quarto filter that intercepts `layout-ncol` / `layout` / `layout-nrow` div attributes before Quarto converts them to `<table>` elements
- Emits CSS grid HTML using the HTML+AST sandwich pattern (same as `callout.lua` and `tabset.lua`), so cell content stays as Pandoc AST and renders correctly through Goldmark
- Fixes the two posts that were intentionally left unrendered in #128 due to code fences with `filename=` disappearing inside layout tables
- Also syncs `categories` → `topics` and adds missing `source:` fields in 122 `.qmd` source files, so re-renders no longer revert those fields

## What the filter handles

| Quarto syntax | CSS output |
|---|---|
| `layout-ncol=N` | `md:grid-cols-N` |
| `layout="[70,30]"` | `md:grid-cols-[70fr_30fr]` |
| `layout="[[3,1]]"` | `md:grid-cols-[3fr_1fr]` (one grid per row for multi-row) |
| `layout-valign="center"` | `items-center` |
| Extra classes (e.g. `.column-body-outset-right`) | Passed through on the outer `<div>` |

Mirrors the Tailwind classes already used by `layouts/shortcodes/columns.html`.

## Test plan

- [x] `2025-07-24-parameterized-reports-python` — code blocks with `filename=` inside `layout-ncol=2` now appear in rendered output
- [x] `2025-10-20-quarto-wizard-1-0-0` — same fix; `layout-valign="center"` produces `items-center`
- [x] `2024-01-24-1.4-release` — bare image grids (`layout-ncol=3/4`) and proportional layout (`layout="[[3,1]]"`) render correctly
- [x] `2024-10-15-conf-workshops-materials` — `layout="[70,30]"` proportional columns render correctly
- [ ] All 12 affected posts + `_brand-example.qmd` sub-file re-rendered