### PR TITLE
Auto-hide badge when item type matches page context

### DIFF
--- a/assets/js/search-filter-sort.js
+++ b/assets/js/search-filter-sort.js
@@ -566,6 +566,13 @@
           const imgClass = settings.image_class || '';
           if (imgClass) imgClass.split(' ').filter(Boolean).forEach(c => img.classList.add(c));
         }
+      } else if (settings.placeholder_image) {
+        const img = slot('image');
+        if (img) {
+          img.src = settings.placeholder_image;
+          img.alt = 'Avatar placeholder';
+          img.classList.add('object-contain', 'rounded-xl');
+        }
       }
 
       // Title

--- a/assets/js/search-filter-sort.js
+++ b/assets/js/search-filter-sort.js
@@ -537,14 +537,17 @@
         root.classList.add(...settings.row_class.split(' ').filter(Boolean));
       }
 
-      // Badge
+      // Badge — hide when the current page matches the item type's badge_hide_path
       const badgeEl = slot('badge');
       if (badgeEl && settings.badge_icon) {
-        badgeEl.classList.remove('hidden');
-        const badgeIcon = slot('badge-icon');
-        if (badgeIcon) badgeIcon.className = 'icon-[' + settings.badge_icon + ']';
-        const badgeText = slot('badge-text');
-        if (badgeText) badgeText.textContent = settings.badge_text || '';
+        const hidePath = settings.badge_hide_path || '';
+        if (!hidePath || !window.location.pathname.startsWith(hidePath)) {
+          badgeEl.classList.remove('hidden');
+          const badgeIcon = slot('badge-icon');
+          if (badgeIcon) badgeIcon.className = 'icon-[' + settings.badge_icon + ']';
+          const badgeText = slot('badge-text');
+          if (badgeText) badgeText.textContent = settings.badge_text || '';
+        }
       }
 
       // Image

--- a/data/items.yaml
+++ b/data/items.yaml
@@ -1,4 +1,5 @@
 blog:
+  badge_hide_path: "/blog/"
   badge_icon: "boxicons--message-filled"
   badge_text: "blog post"
   card_class: "bg-gray-100/25"
@@ -10,6 +11,7 @@ blog:
   tile_class: "bg-gray-100/25"
 
 cheatsheets:
+  badge_hide_path: "/resources/cheatsheets/"
   badge_icon: "boxicons--file-code-filled"
   badge_text: "cheatsheet"
   card_class: "bg-gray-100/25"
@@ -22,6 +24,7 @@ cheatsheets:
   tile_class: "bg-gray-100/25"
 
 events:
+  badge_hide_path: "/events/"
   badge_icon: "boxicons--calendar-event-filled"
   badge_text: "event"
   card_class: "bg-gray-100/25"
@@ -33,6 +36,7 @@ events:
   tile_class: "bg-gray-100/25"
 
 people:
+  badge_hide_path: "/people/"
   badge_icon: "boxicons--face-filled"
   badge_text: "person"
   card_class: ""
@@ -48,6 +52,7 @@ people:
   title_class: "@max-venti:self-center"
 
 software:
+  badge_hide_path: "/software/"
   badge_icon: "boxicons--hexagon-filled"
   badge_text: "software"
   card_class: "bg-gray-100/25"
@@ -59,6 +64,7 @@ software:
   tile_class: "bg-gray-100/25"
 
 videos:
+  badge_hide_path: "/resources/videos/"
   badge_icon: "boxicons--video-filled"
   badge_text: "video"
   card_class: "bg-gray-100/25"

--- a/layouts/partials/item-templates.html
+++ b/layouts/partials/item-templates.html
@@ -6,9 +6,15 @@
   templates and fills data-slot elements from the item-index JSON.
 */}}
 
-{{/* Item settings for JS */}}
+{{/* Item settings for JS — inject resolved asset URLs where needed */}}
+{{ $settings := site.Data.items }}
+{{ $placeholder := resources.Get "images/person-placeholder.svg" }}
+{{ with $placeholder }}
+  {{ $people := merge (index $settings "people") (dict "placeholder_image" .RelPermalink) }}
+  {{ $settings = merge $settings (dict "people" $people) }}
+{{ end }}
 <script id="item-settings" type="application/json">
-  {{ site.Data.items | jsonify | safeJS }}
+  {{ $settings | jsonify | safeJS }}
 </script>
 
 {{/* ============================================================

--- a/layouts/partials/item-templates.html
+++ b/layouts/partials/item-templates.html
@@ -21,7 +21,7 @@
       {{/* Badge — hidden by default, JS shows if applicable */}}
       <span data-slot="badge" class="card-badge absolute top-2 @max-venti:right-2 @venti:left-2 z-10 hidden">
         <span data-slot="badge-icon"></span>
-        <span data-slot="badge-text" class="font-semibold uppercase tracking-wide hidden @xs:inline"></span>
+        <span data-slot="badge-text" class="font-semibold uppercase tracking-wide hidden @short:inline"></span>
       </span>
 
       {{/* Image */}}

--- a/layouts/partials/item.html
+++ b/layouts/partials/item.html
@@ -706,7 +706,7 @@
         <span class="card-badge absolute top-2 @max-venti:right-2 @venti:left-2 z-10">
 
           <span class="icon-[{{ $card_settings.badge_icon }}]"></span>
-          <span class="font-semibold uppercase tracking-wide hidden @xs:inline">{{ $card_settings.badge_text }}</span>
+          <span class="font-semibold uppercase tracking-wide hidden @short:inline">{{ $card_settings.badge_text }}</span>
 
         </span>
       {{ end }}

--- a/layouts/partials/item.html
+++ b/layouts/partials/item.html
@@ -55,6 +55,15 @@
   {{ errorf "item partial: no card_settings in data/items.yaml for card_type '%s' (slug: '%s')" $card_type $slug }}
 {{ end }}
 
+{{/* Auto-hide badge when item type matches the current page's section */}}
+{{ if not $hide_badge }}
+  {{ with $card_settings.badge_hide_path }}
+    {{ if hasPrefix (page).RelPermalink . }}
+      {{ $hide_badge = true }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
 {{/* ============================================================
      TITLE
      ============================================================ */}}

--- a/layouts/partials/item.html
+++ b/layouts/partials/item.html
@@ -296,6 +296,11 @@
           "tall"   160
           "grande" 160
         ) }}
+      {{ else if $is_person }}
+        {{ $placeholder := resources.Get "images/person-placeholder.svg" }}
+        {{ with $placeholder }}
+          <img src="{{ .RelPermalink }}" alt="Avatar placeholder" class="mx-auto h-full object-contain rounded-xl" />
+        {{ end }}
       {{ end }}
     </div>
 
@@ -723,6 +728,11 @@
           "tall"   320
           "grande" 640
         ) }}
+      {{ else if $is_person }}
+        {{ $placeholder := resources.Get "images/person-placeholder.svg" }}
+        {{ with $placeholder }}
+          <img src="{{ .RelPermalink }}" alt="Avatar placeholder" class="mx-auto h-full object-contain rounded-xl" />
+        {{ end }}
       {{ end }}
     </div>
 

--- a/layouts/people/term.html
+++ b/layouts/people/term.html
@@ -83,7 +83,7 @@
 
   <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mx-2 md:mx-0 mb-6">
     {{ range $software }}
-      {{ partial "item.html" (dict "page" . "hide-badge" true "hide-views" true) }}
+      {{ partial "item.html" (dict "page" . "hide-views" true) }}
     {{ end }}
   </div>
   {{ end }}


### PR DESCRIPTION
## Summary
- Add `badge_hide_path` per item type in `data/items.yaml`; both Hugo and JS automatically suppress the badge when the current page URL matches (e.g. no "blog post" badges on `/blog/`)
- Show badge text at the `@short` container breakpoint (15rem) instead of `@xs` (20rem)
- Show software badges on personal profile pages