### PR TITLE
Update raghilda blog post date to 2026-04-14

### DIFF
--- a/content/blog/rag-with-raghilda/index.md
+++ b/content/blog/rag-with-raghilda/index.md
@@ -1,6 +1,6 @@
 ---
 title: "RAG with raghilda"
-date: '2026-03-30'
+date: '2026-04-14'
 description: |
   An introduction to building retrieval-augmented generation systems with raghilda.
 people:


### PR DESCRIPTION
## Summary
- Updates the raghilda blog post publication date from `2026-03-30` to `2026-04-14` (today's date)

As mentioned in https://github.com/posit-dev/open-source-website/pull/153#issuecomment-4226713865, updating the date to reflect the actual publication date.