### PR TITLE
Add source-specific announcements for legacy blog redirects

### DIFF
--- a/assets/js/search-filter-sort.js
+++ b/assets/js/search-filter-sort.js
@@ -367,6 +367,7 @@
         const featured = this.container.parentElement?.querySelector('[data-featured]');
         if (featured) featured.classList.add('hidden');
       }
+      this._updateSourceAnnouncement();
       if (this.state.showFilters || this._hasActiveFilters()) this._showControls();
       this._updateShowBtnLabel();
       this._bindControls();
@@ -936,6 +937,7 @@
       this._updateCount(filtered.length);
       this._updateEmpty(filtered.length === 0);
       this._updateResetBtn();
+      this._updateSourceAnnouncement();
       this._updateURL();
 
       if (this._interactive && this.controlsEl) {
@@ -1026,6 +1028,27 @@
     _updateEmpty(isEmpty) {
       const emptyEl = this.container.parentNode.querySelector('[data-filter-empty]');
       if (emptyEl) emptyEl.classList.toggle('hidden', !isEmpty);
+    }
+
+    _updateSourceAnnouncement() {
+      const parent = this.container.parentElement;
+      if (!parent) return;
+      const announcements = parent.querySelectorAll('[data-source-announcement]');
+      if (!announcements.length) return;
+
+      // Extract source value from search query (e.g. "source:quarto" → "quarto")
+      const match = this.state.search.match(/\bsource:(\S+)/i);
+      const source = match ? match[1].toLowerCase().replace(/^"(.*)"$/, '$1') : '';
+
+      announcements.forEach(el => {
+        el.classList.toggle('hidden', el.dataset.sourceAnnouncement !== source);
+      });
+
+      // Also hide featured when a source announcement is visible
+      const featured = parent.querySelector('[data-featured]');
+      if (featured && source) {
+        featured.classList.add('hidden');
+      }
     }
 
     _updateURL() {

--- a/content/blog/q/ai/_index.md
+++ b/content/blog/q/ai/_index.md
@@ -1,3 +1,7 @@
 ---
 title: AI
 ---
+
+### The AI blog has a new home
+
+The AI blog has moved to the [Posit Open Source blog](/blog/). All past and future AI posts now live here alongside posts from our other open-source projects.

--- a/content/blog/q/education/_index.md
+++ b/content/blog/q/education/_index.md
@@ -1,3 +1,7 @@
 ---
 title: Education
 ---
+
+### The Education blog has a new home
+
+The Education blog has moved to the [Posit Open Source blog](/blog/). All past and future Education posts now live here alongside posts from our other open-source projects.

--- a/content/blog/q/great-tables/_index.md
+++ b/content/blog/q/great-tables/_index.md
@@ -2,3 +2,7 @@
 title: Great Tables
 query: "great-tables"
 ---
+
+### The Great Tables blog has a new home
+
+The Great Tables blog has moved to the [Posit Open Source blog](/blog/). All past and future Great Tables posts now live here alongside posts from our other open-source projects.

--- a/content/blog/q/plotnine/_index.md
+++ b/content/blog/q/plotnine/_index.md
@@ -1,3 +1,7 @@
 ---
 title: Plotnine
 ---
+
+### The Plotnine blog has a new home
+
+The Plotnine blog has moved to the [Posit Open Source blog](/blog/). All past and future Plotnine posts now live here alongside posts from our other open-source projects.

--- a/content/blog/q/pointblank/_index.md
+++ b/content/blog/q/pointblank/_index.md
@@ -1,3 +1,7 @@
 ---
 title: Pointblank
 ---
+
+### The Pointblank blog has a new home
+
+The Pointblank blog has moved to the [Posit Open Source blog](/blog/). All past and future Pointblank posts now live here alongside posts from our other open-source projects.

--- a/content/blog/q/positron/_index.md
+++ b/content/blog/q/positron/_index.md
@@ -1,3 +1,7 @@
 ---
 title: Positron
 ---
+
+### The Positron blog has a new home
+
+The Positron blog has moved to the [Posit Open Source blog](/blog/). All past and future Positron posts now live here alongside posts from our other open-source projects.

--- a/content/blog/q/quarto/_index.md
+++ b/content/blog/q/quarto/_index.md
@@ -1,3 +1,7 @@
 ---
 title: Quarto
 ---
+
+### The Quarto blog has a new home
+
+The Quarto blog has moved to the [Posit Open Source blog](/blog/). All past and future Quarto posts now live here alongside posts from our other open-source projects.

--- a/content/blog/q/rstudio/_index.md
+++ b/content/blog/q/rstudio/_index.md
@@ -1,7 +1,3 @@
 ---
 title: RStudio
 ---
-
-### The RStudio blog has a new home
-
-The RStudio blog has moved to the [Posit Open Source blog](/blog/). All past and future RStudio posts now live here alongside posts from our other open-source projects.

--- a/content/blog/q/rstudio/_index.md
+++ b/content/blog/q/rstudio/_index.md
@@ -1,3 +1,7 @@
 ---
 title: RStudio
 ---
+
+### The RStudio blog has a new home
+
+The RStudio blog has moved to the [Posit Open Source blog](/blog/). All past and future RStudio posts now live here alongside posts from our other open-source projects.

--- a/content/blog/q/shiny/_index.md
+++ b/content/blog/q/shiny/_index.md
@@ -1,3 +1,7 @@
 ---
 title: Shiny
 ---
+
+### The Shiny blog has a new home
+
+The Shiny blog has moved to the [Posit Open Source blog](/blog/). All past and future Shiny posts now live here alongside posts from our other open-source projects.

--- a/content/blog/q/tidyverse/_index.md
+++ b/content/blog/q/tidyverse/_index.md
@@ -1,3 +1,7 @@
 ---
 title: Tidyverse
 ---
+
+### The Tidyverse blog has a new home
+
+The Tidyverse blog has moved to the [Posit Open Source blog](/blog/). All past and future Tidyverse posts now live here alongside posts from our other open-source projects.

--- a/layouts/blog/blog-query.html
+++ b/layouts/blog/blog-query.html
@@ -12,6 +12,12 @@
 
   <h1 class="text-4xl font-medium text-gray-500 mb-2">{{ .Title }} blog posts</h1>
 
+  {{ with .Content }}
+  <div class="prose max-w-none my-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+    {{ . }}
+  </div>
+  {{ end }}
+
   <div class="prose my-4">
     {{ partial "button.html" (dict "url" "/blog/" "text" "All blog posts" "icon-left" "boxicons--chevron-left" "size" "small") }}
   </div>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -9,6 +9,15 @@
     {{ . }}
   </div>
   {{ end }}
+
+  {{ range (site.GetPage "/blog/q").Sections }}
+    {{ $source := .Params.query | default .File.ContentBaseName }}
+    {{ with .Content }}
+    <div data-source-announcement="{{ $source }}" class="hidden prose max-w-none mb-8 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+      {{ . }}
+    </div>
+    {{ end }}
+  {{ end }}
   {{ end }}
 
   {{ $baseCfg := site.Data.filters.blog }}


### PR DESCRIPTION
## Summary

- Adds announcement banners for visitors arriving from legacy blogs (Quarto, Shiny, Tidyverse, etc.) informing them that posts have moved to the unified Posit Open Source blog
- Announcements render on `/blog/q/*` pages for no-JS users and dynamically on `/blog/?q=source:*` for JS users
- Announcement content lives in the `_index.md` body of each `/content/blog/q/<source>/` section, making it easy to customize per source

## Test plan

- [x] Visit `/blog/?q=source:quarto` and verify the Quarto announcement banner appears
- [x] Visit `/blog/?q=source:shiny` and verify the Shiny announcement banner appears
- [x] Verify the featured section is hidden when a source announcement is visible
- [x] Clear the search query and verify the announcement disappears and featured reappears
- [x] Disable JS and visit `/blog/q/quarto/` directly to verify the no-JS fallback shows the announcement
- [x] Verify no announcement appears on the default `/blog/` page (no source query)