### PR TITLE
Add deploy preview support for fork PRs

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -3,6 +3,10 @@ name: Build and Deploy to Netlify
 on:
   workflow_call:
     inputs:
+      ref:
+        description: "Git ref to check out. Defaults to the SHA that triggered the workflow."
+        type: string
+        default: ""
       hugo-flags:
         description: "Extra flags for the Hugo build command (e.g. --buildFuture)"
         type: string
@@ -39,6 +43,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Hugo
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,20 +3,99 @@ name: Deploy Preview
 on:
   pull_request:
     branches: ["main"]
+  pull_request_target:
+    branches: ["main"]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: deploy-preview-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  notify-fork-pr:
+    # Post a sticky comment on fork PRs from non-members explaining /deploy-preview.
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.fork == true &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post fork preview notice
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: fork-deploy-notice
+          message: |
+            ## Preview not available
+
+            This PR is from a fork and cannot deploy a preview automatically.
+            A maintainer can comment `/deploy-preview` to trigger one.
+
   build-and-deploy:
+    # Three paths to a preview deploy:
+    # 1. pull_request from a branch in this repo (non-fork)
+    # 2. pull_request_target from a fork, if the author is an org member
+    # 3. /deploy-preview comment from a maintainer (for external fork PRs)
+    if: >
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork != true
+      ) ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.fork == true &&
+        (
+          github.event.pull_request.author_association == 'MEMBER' ||
+          github.event.pull_request.author_association == 'OWNER' ||
+          github.event.pull_request.author_association == 'COLLABORATOR'
+        )
+      ) ||
+      (
+        github.event.issue.pull_request &&
+        (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        ) &&
+        startsWith(github.event.comment.body, '/deploy-preview')
+      )
     uses: ./.github/workflows/build-deploy.yml
     with:
+      ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number || github.event.issue.number) }}
       hugo-flags: "--buildFuture"
       deploy-context: "preview"
     secrets: inherit
 
   detect-content:
+    if: >
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork != true
+      ) ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.fork == true &&
+        (
+          github.event.pull_request.author_association == 'MEMBER' ||
+          github.event.pull_request.author_association == 'OWNER' ||
+          github.event.pull_request.author_association == 'COLLABORATOR'
+        )
+      ) ||
+      (
+        github.event.issue.pull_request &&
+        (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        ) &&
+        startsWith(github.event.comment.body, '/deploy-preview')
+      )
     runs-on: ubuntu-latest
     outputs:
       has-changes: ${{ steps.detect-content.outputs.has-changes }}
@@ -24,6 +103,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number || github.event.issue.number) }}
 
       - name: Detect content changes
         id: detect-content
@@ -51,6 +132,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number || github.event.issue.number) }}
 
       - name: Setup Hugo
         run: |
@@ -102,4 +185,5 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: content-preview-links
+          number: ${{ github.event.pull_request.number || github.event.issue.number }}
           path: /tmp/preview-comment.md


### PR DESCRIPTION
## Summary

- Auto-deploy Netlify previews for fork PRs from org members (via `pull_request_target`)
- Allow maintainers to comment `/deploy-preview` to trigger previews for external fork PRs (via `issue_comment`)
- Post a sticky comment on non-member fork PRs explaining how to request a preview
- Add `ref` input to `build-deploy.yml` so callers can specify a PR merge ref for checkout

## Test plan

- [x] Route 1: non-fork PR deploys preview automatically (`pull_request`)
- [ ] Route 2: fork PR from org member auto-deploys (`pull_request_target`)
- [ ] Route 3: `/deploy-preview` comment from maintainer deploys (`issue_comment`)
- [ ] Route 4: fork PR from non-member skips build, posts sticky comment
- [ ] Route 5: `/deploy-preview` from non-member is ignored
- [ ] Route 6: regular comment on PR is ignored