### PR TITLE
Fix Netlify cleanup for fork PRs and remove debug job

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,17 +13,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  debug:
-    if: github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "event_name: ${{ github.event_name }}"
-          echo "fork: ${{ github.event.pull_request.head.repo.fork }}"
-          echo "author_association: ${{ github.event.pull_request.author_association }}"
-          echo "head_repo: ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "base_repo: ${{ github.event.pull_request.base.repo.full_name }}"
-
   notify-fork-pr:
     # Post a sticky comment on fork PRs from non-members explaining /deploy-preview.
     if: >

--- a/.github/workflows/netlify-cleanup.yml
+++ b/.github/workflows/netlify-cleanup.yml
@@ -4,14 +4,14 @@ on:
   # Trigger when a branch is deleted
   delete:
   # Trigger when a PR is closed (merged or dismissed)
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:
   delete-netlify-deploys:
     # Run only if it's a PR close event OR a Branch delete event (ignore tag deletions)
     if: >
-      github.event_name == 'pull_request' || 
+      github.event_name == 'pull_request_target' ||
       (github.event_name == 'delete' && github.event.ref_type == 'branch')
     runs-on: ubuntu-latest
     
@@ -37,7 +37,15 @@ jobs:
           RESPONSE=$(curl -s -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
             "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?branch=$TARGET_BRANCH&per_page=100")
 
-          # 3. Parse IDs
+          # 3. Validate response is a JSON array
+          if ! echo "$RESPONSE" | jq -e 'type == "array"' > /dev/null 2>&1; then
+            echo "Unexpected API response (not a JSON array):"
+            echo "$RESPONSE" | head -5
+            echo "No deploys deleted for branch: $TARGET_BRANCH"
+            exit 0
+          fi
+
+          # 4. Parse IDs
           DEPLOY_IDS=$(echo "$RESPONSE" | jq -r '.[].id')
 
           if [ -z "$DEPLOY_IDS" ] || [ "$DEPLOY_IDS" == "null" ]; then
@@ -45,7 +53,7 @@ jobs:
             exit 0
           fi
 
-          # 4. Delete them
+          # 5. Delete them
           for ID in $DEPLOY_IDS; do
             echo "Deleting deploy ID: $ID"
             curl -s -X DELETE -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \


### PR DESCRIPTION
## Summary

- Switch `netlify-cleanup.yml` trigger from `pull_request` to `pull_request_target` so the workflow has access to secrets when cleaning up deploys from fork PRs
- Add response validation before parsing the Netlify API response, so unexpected responses fail gracefully instead of with a cryptic `jq` error
- Remove the temporary `debug` job from `deploy-preview.yml` (no longer needed after testing)

## Context

After adding deploy preview support for fork PRs (#179, #183), closing a fork PR triggers `netlify-cleanup.yml` via `pull_request`. But `pull_request` events for fork PRs don't have access to repo secrets, so the Netlify API call fails with an empty auth token.

`pull_request_target` has secrets for all PRs (fork and non-fork) and is safe here because the cleanup workflow never checks out PR code — it only calls the Netlify API.

## Test plan

- [ ] Close a fork PR and verify the cleanup run succeeds
- [ ] Close a non-fork PR and verify cleanup still works