### PR TITLE
Fix preview links showing unrelated content changes

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -122,8 +122,10 @@ jobs:
       - name: Detect content changes
         id: detect-content
         run: |
-          git fetch origin main --depth=1
-          CHANGED=$(git diff --name-only origin/main -- 'content/' \
+          # HEAD is refs/pull/N/merge — a merge commit whose first parent is
+          # the base branch.  Diffing against HEAD~1 gives exactly the PR's
+          # changes, even when main has moved ahead of the merge ref.
+          CHANGED=$(git diff --name-only HEAD~1 -- 'content/' \
             | { grep -E '/_?index\.(md|qmd|ipynb|Rmd|Rmarkdown|markdown|html)$' || true; })
 
           if [ -z "$CHANGED" ]; then


### PR DESCRIPTION
## Summary

- Diff against the merge commit's first parent (`HEAD~1`) instead of `origin/main` when detecting content changes for preview links

## Context

The `detect-content` job checks out `refs/pull/N/merge` then diffs against a freshly fetched `origin/main`. When main has moved ahead since the merge ref was last updated, files added to main show up as "changed" — producing preview links for content the PR didn't touch.

For example, PR #173 only changes `/people/hannah-frick/` but got a preview link to `/blog/2026-03-30_rag-with-raghilda/` (added to main after the PR was opened).

Since `refs/pull/N/merge` is a merge commit, its first parent (`HEAD~1`) is the base branch state at merge time. Diffing against that gives exactly the PR's changes.

## Test plan

- [ ] Trigger a preview on a PR where main has moved ahead — verify only PR-changed content appears in preview links