### PR TITLE
Accept timestamp dates in blog validation

### DIFF
--- a/scripts/test-validate-blog-posts.py
+++ b/scripts/test-validate-blog-posts.py
@@ -235,9 +235,8 @@ class TestCheckDateFormat:
         ctx = make_ctx(tmp_path)
         p = post_path(tmp_path, "my-post")
         fm = {"date": datetime.datetime(2026, 4, 15, tzinfo=datetime.timezone.utc)}
-        issues = v.check_date_format(p, fm, ctx)
-        assert len(issues) == 1
-        assert "timestamp" in issues[0].message
+        # Quarto rendering produces timestamps; Hugo handles them fine
+        assert v.check_date_format(p, fm, ctx) == []
 
     def test_bad_string(self, tmp_path):
         ctx = make_ctx(tmp_path)
@@ -251,15 +250,14 @@ class TestCheckDateFormat:
         p = post_path(tmp_path, "my-post")
         assert v.check_date_format(p, {}, ctx) == []
 
-    def test_timestamp_ported_is_warning(self, tmp_path):
+    def test_timestamp_ported_is_accepted(self, tmp_path):
         ctx = make_ctx(tmp_path)
         p = post_path(tmp_path, "old", "post")
         fm = {
             "date": datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc),
             "ported_from": "quarto",
         }
-        issues = v.check_date_format(p, fm, ctx)
-        assert issues[0].level == "warning"
+        assert v.check_date_format(p, fm, ctx) == []
 
 
 # --- check_date_past ---

--- a/scripts/validate-blog-posts.py
+++ b/scripts/validate-blog-posts.py
@@ -216,13 +216,9 @@ def check_date_format(
         return []  # plain date object — valid
 
     if isinstance(date_val, datetime.datetime):
-        return [
-            Issue(
-                post_path,
-                f"`date` must be YYYY-MM-DD, not a timestamp. Found: `{date_val}`.",
-                sev,
-            )
-        ]
+        # Quarto rendering can turn YYYY-MM-DD into a full timestamp
+        # (e.g. 2026-04-09T00:00:00.000Z). Hugo handles these fine.
+        return []
 
     if isinstance(date_val, str):
         try:


### PR DESCRIPTION
## Summary

- Quarto rendering turns `YYYY-MM-DD` dates into full timestamps (e.g. `2026-04-09T00:00:00.000Z`). Hugo handles these fine, so the validator shouldn't flag them as errors.
- Discovered while running validation against #170.

## Test plan

- [ ] Run `uv run scripts/validate-blog-posts.py` against a post with a Quarto-rendered timestamp date and confirm no error