### PR TITLE
Add debug logging for fork PR author_association

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -14,16 +14,6 @@ permissions:
 
 jobs:
   debug-association:
-    if: >
-      (
-        github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.fork == true
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/deploy-preview')
-      )
     runs-on: ubuntu-latest
     steps:
       - name: Log author association

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -44,10 +44,6 @@ jobs:
       github.event.pull_request.author_association != 'COLLABORATOR'
     runs-on: ubuntu-latest
     steps:
-      - name: Log author association
-        run: |
-          echo "author_association: ${{ github.event.pull_request.author_association }}"
-          echo "user: ${{ github.event.pull_request.user.login }}"
       - name: Post fork preview notice
         uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,6 +13,17 @@ permissions:
   pull-requests: write
 
 jobs:
+  debug-association:
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log author association
+        run: |
+          echo "author_association: ${{ github.event.pull_request.author_association }}"
+          echo "user: ${{ github.event.pull_request.user.login }}"
+
   notify-fork-pr:
     # Post a sticky comment on fork PRs from non-members explaining /deploy-preview.
     if: >
@@ -23,6 +34,10 @@ jobs:
       github.event.pull_request.author_association != 'COLLABORATOR'
     runs-on: ubuntu-latest
     steps:
+      - name: Log author association
+        run: |
+          echo "author_association: ${{ github.event.pull_request.author_association }}"
+          echo "user: ${{ github.event.pull_request.user.login }}"
       - name: Post fork preview notice
         uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,14 +15,24 @@ permissions:
 jobs:
   debug-association:
     if: >
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.fork == true
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.fork == true
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/deploy-preview')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Log author association
         run: |
-          echo "author_association: ${{ github.event.pull_request.author_association }}"
-          echo "user: ${{ github.event.pull_request.user.login }}"
+          echo "event_name: ${{ github.event_name }}"
+          echo "pr.author_association: ${{ github.event.pull_request.author_association }}"
+          echo "pr.user: ${{ github.event.pull_request.user.login }}"
+          echo "comment.author_association: ${{ github.event.comment.author_association }}"
+          echo "comment.user: ${{ github.event.comment.user.login }}"
 
   notify-fork-pr:
     # Post a sticky comment on fork PRs from non-members explaining /deploy-preview.


### PR DESCRIPTION
## Summary

- Investigating why `pull_request_target` events treat org member fork PRs as non-members (posting "Preview not available") while `issue_comment` events from the same user work correctly
- Adds an ungated `debug-association` job that logs `event_name`, `pull_request.author_association`, and `comment.author_association` on every trigger type for comparison

## Next steps

Once merged, close/reopen PR #170 to trigger `pull_request_target` and capture the actual values. Then comment `/deploy-preview` to capture the `issue_comment` values.

Temporary — will remove once we have the data.