### PR TITLE
Post blog validation comments on fork PRs

### DIFF
--- a/.github/workflows/comment-blog-validation.yml
+++ b/.github/workflows/comment-blog-validation.yml
@@ -1,0 +1,37 @@
+name: Comment Blog Validation
+
+on:
+  workflow_run:
+    workflows: ["Validate Blog Posts"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    steps:
+      - name: Download report
+        uses: actions/download-artifact@v4
+        with:
+          name: blog-validation-report
+          path: ./report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat ./report/pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Post results comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: blog-validation
+          recreate: true
+          path: ./report/report.md
+          number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/validate-blog-posts.yml
+++ b/.github/workflows/validate-blog-posts.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   validate:
@@ -48,13 +47,19 @@ jobs:
             $FILES > /tmp/validation-report.md || EXIT_CODE=$?
           echo "exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
-      - name: Post results comment
+      - name: Stash PR number with report
         if: steps.changed.outputs.found == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        run: |
+          mkdir -p /tmp/report
+          cp /tmp/validation-report.md /tmp/report/report.md
+          echo "${{ github.event.pull_request.number }}" > /tmp/report/pr-number.txt
+
+      - name: Upload report
+        if: steps.changed.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
         with:
-          header: blog-validation
-          recreate: true
-          path: /tmp/validation-report.md
+          name: blog-validation-report
+          path: /tmp/report/
 
       - name: Fail on errors
         if: steps.validate.outputs.exit-code != '0' && steps.changed.outputs.found == 'true'


### PR DESCRIPTION
## Summary

- `sticky-pull-request-comment` fails on fork PRs because `pull_request` workflows get a read-only `GITHUB_TOKEN` regardless of the `permissions:` block (e.g. [run 24529154129](https://github.com/posit-dev/open-source-website/actions/runs/24529154129) on [PR #170](https://github.com/posit-dev/open-source-website/pull/170)).
- Validation still runs on `pull_request`, but it now uploads the markdown report + PR number as an artifact and drops the inline comment step.
- A new `comment-blog-validation.yml` workflow triggers on `workflow_run`, runs from `main` with a write-capable token, downloads the artifact, and posts the sticky comment.
- Untrusted PR code only runs with the read-only token; the write-token job only consumes a pre-rendered markdown artifact — code and write-capable token never share a job.

## Test plan

- [ ] Merge, then confirm on the next internal blog-post PR that the sticky comment still appears.
- [ ] Confirm on a fork PR (e.g. re-run validation on [#170](https://github.com/posit-dev/open-source-website/pull/170) after merge) that the comment now posts.
- [ ] Confirm that a PR touching `content/blog/**` but with no `index.md` changes does not leave a stale comment or error.
- [ ] Confirm "Fail on errors" still turns the PR check red when validation finds problems.