### PR TITLE
Simplify deploy-preview: drop pull_request_target deploy path

### DIFF
--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -7,17 +7,17 @@ Help the user create a new blog post for the Posit open-source website. Work thr
 
 ## Step 0: Preflight check
 
-Description: "Checking that you're working from a direct clone of the repo, not a fork"
+Description: "Checking whether you're working from a direct clone or a fork"
 
 ```sh
 git remote get-url origin
 ```
 
-If the remote URL does not contain `posit-dev/open-source-website`, warn the user:
+If the remote URL does not contain `posit-dev/open-source-website`, note to the user:
 
-> It looks like you're working from a fork rather than a direct clone. Members of the `posit-dev` org have Write access and should clone `posit-dev/open-source-website` directly — this ensures the deploy preview action works when you open a PR.
+> Looks like you're working from a fork. That's supported — you'll just need to comment `/deploy-preview` on your PR once to trigger the preview build (fork PRs can't auto-deploy because the workflow runs with a read-only token). If you're a member of the `posit-dev` org, the smoother path is to clone `posit-dev/open-source-website` directly so branch PRs get auto-deploy.
 
-Then ask whether they'd like to continue anyway or stop to re-clone.
+Then ask whether they'd like to continue from the fork or stop to re-clone.
 
 ## Step 1: Gather information
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,25 +13,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  debug-association:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Log author association
-        run: |
-          echo "event_name: ${{ github.event_name }}"
-          echo "pr.author_association: ${{ github.event.pull_request.author_association }}"
-          echo "pr.user: ${{ github.event.pull_request.user.login }}"
-          echo "comment.author_association: ${{ github.event.comment.author_association }}"
-          echo "comment.user: ${{ github.event.comment.user.login }}"
-
   notify-fork-pr:
-    # Post a sticky comment on fork PRs from non-members explaining /deploy-preview.
+    # Post a sticky comment on every fork PR explaining /deploy-preview.
+    # Fork pushes get a read-only GITHUB_TOKEN with no access to secrets, so
+    # auto-deploy isn't possible regardless of the author's role. Every
+    # fork-PR author needs the same prompt — including members, who can
+    # self-trigger by commenting.
     if: >
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.fork == true &&
-      github.event.pull_request.author_association != 'MEMBER' &&
-      github.event.pull_request.author_association != 'OWNER' &&
-      github.event.pull_request.author_association != 'COLLABORATOR'
+      github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
     steps:
       - name: Post fork preview notice
@@ -42,13 +32,14 @@ jobs:
             ## Preview not available
 
             This PR is from a fork and cannot deploy a preview automatically.
-            A maintainer can comment `/deploy-preview` to trigger one.
+            A repository member can comment `/deploy-preview` to trigger one
+            (including you, if you have member access).
 
   build-and-deploy:
-    # Three paths to a preview deploy:
-    # 1. pull_request for non-fork PRs (workflow changes in PR are testable)
-    # 2. pull_request_target for fork PRs from org members (has secrets)
-    # 3. /deploy-preview comment from a maintainer (for external fork PRs)
+    # Two paths to a preview deploy:
+    # 1. pull_request for non-fork PRs (auto-deploy)
+    # 2. /deploy-preview comment from a member (covers fork PRs and anyone
+    #    without push access; members with fork PRs self-trigger this way)
     concurrency:
       group: deploy-preview-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
@@ -56,15 +47,6 @@ jobs:
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.fork != true
-      ) ||
-      (
-        github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.fork == true &&
-        (
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.author_association == 'OWNER' ||
-          github.event.pull_request.author_association == 'COLLABORATOR'
-        )
       ) ||
       (
         github.event.issue.pull_request &&
@@ -90,15 +72,6 @@ jobs:
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.fork != true
-      ) ||
-      (
-        github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.fork == true &&
-        (
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.author_association == 'OWNER' ||
-          github.event.pull_request.author_association == 'COLLABORATOR'
-        )
       ) ||
       (
         github.event.issue.pull_request &&

--- a/NETLIFY_SETUP.md
+++ b/NETLIFY_SETUP.md
@@ -65,7 +65,8 @@ Once the secrets are added, you can trigger a deployment by:
 ## Expected Behavior
 
 - **Push to main**: Deploys to production at your Netlify site URL
-- **Pull requests**: Creates a unique preview URL and posts it as a comment on the PR
+- **Pull requests from a branch on this repo**: Creates a unique preview URL and posts it as a comment on the PR
+- **Pull requests from a fork**: Don't auto-deploy (fork workflows run with a read-only token and no access to secrets). A member can comment `/deploy-preview` on the PR to trigger a preview build.
 - **Manual trigger**: Can manually deploy from the Actions tab
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ See [`content/blog/_authoring-guide.md`](content/blog/_authoring-guide.md) for f
 
 **Quick start with Claude Code:**
 
-1. Clone this repository directly (don't fork — org members have Write access)
+1. Clone this repository directly if you're an org member (you have Write access via the Everyone team, so branch PRs get auto-preview). Working from a fork is supported too — you'll just comment `/deploy-preview` on your PR to trigger a preview build.
 2. Open Claude Code in the project root
 3. Run `/new-post` — it will guide you through scaffolding, frontmatter, branch creation, and environment setup interactively
 
@@ -459,6 +459,7 @@ The site uses GitHub Actions for CI/CD (`.github/workflows/deploy.yml`):
 1. **Pull Requests**: Automatically deploy preview builds with unique URLs
    - Preview URLs are posted as PR comments
    - Previews are cleaned up when PRs close
+   - Fork PRs don't auto-deploy (read-only token, no secrets). A member can comment `/deploy-preview` on the PR to trigger a preview build.
 
 2. **Main Branch**: Automatically deploy to production on Netlify
    - Triggers on push to `main`

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -2,7 +2,9 @@
 
 All blog posts should be submitted as a pull request against `main` — don't push directly to the branch. This ensures every post gets a Netlify preview before it goes live.
 
-**Posit org members:** Clone the repo directly — don't fork it. You have Write access to `posit-dev/open-source-website`, so you can push branches straight to the main repo and open a PR from there.
+**Posit org members:** Clone the repo directly — don't fork it. As a member of the Everyone team you have Write access to `posit-dev/open-source-website`, so you can push branches straight to the main repo and open a PR from there. This is the smoothest path because branch PRs get a Netlify preview automatically.
+
+If you already work from a fork (your own preference, or a personal-fork-first workflow), that's fine too — you'll just need to comment `/deploy-preview` on your PR once to trigger the preview build. Fork PRs can't auto-deploy because GitHub gives the workflow a read-only token with no access to our Netlify secrets.
 
 If you're using Claude Code, the `/new-post` skill will handle scaffolding, frontmatter, branch creation, and environment setup interactively.
 
@@ -93,6 +95,8 @@ Reviewers and CI can build the site without re-executing your code.
 ### Option 1: PR preview (simplest)
 
 Open a pull request against `main`. GitHub Actions will build the site and post a Netlify preview URL as a comment on the PR — no local setup required.
+
+If your PR is from a fork, auto-deploy is disabled (fork workflows run with a read-only token). A member — including you, if you have member access — can comment `/deploy-preview` on the PR to trigger the build.
 
 The preview URL looks like `https://<hash>--posit-open-source.netlify.app`. All posts use the format `/blog/YYYY-MM-DD_slug/`, where date and slug come from frontmatter:
 


### PR DESCRIPTION
## Summary

The fork-PR auto-deploy path via `pull_request_target` was broken. For org members with prior merged commits (e.g. Thomas on #170), `github.event.pull_request.author_association` returns `CONTRIBUTOR` instead of `MEMBER`, so their fork PRs were getting the "preview not available" notice instead of auto-deploying — confirmed empirically by the debug job added in #193.

Fixing the gate properly would need a PAT with `read:org` scope (not obtainable for posit-dev) or a collaborators-API plumbing job. Instead, this PR drops the `pull_request_target` deploy path entirely and matches the pattern quarto-web landed on after hitting the same bug: fork PRs always require a `/deploy-preview` comment from a member.

## Changes

- Remove `debug-association` job (from #193).
- `notify-fork-pr` now fires on every fork PR (not just non-members). Wording updated so members know they can self-trigger.
- Remove the `pull_request_target` arm from `build-and-deploy` and `detect-content`. The trigger stays so `notify-fork-pr` can still post a sticky comment with write permissions.
- `comment.author_association` gate on `/deploy-preview` is unchanged — same theoretical quirk applies, empirically works, tolerable for now.
- Docs (authoring guide, `/new-post` preflight, README, NETLIFY_SETUP) now describe fork as a supported workflow with the manual-comment cost, instead of framing it as a blocker.

## Tradeoff

Members working from a fork (rare, but possible) lose auto-deploy — they'll need to comment `/deploy-preview` once per PR. Acceptable; the alternative was keeping a known-broken gate or building org-membership REST plumbing we can't power without a suitable PAT.

## Test plan

- [ ] Merge to main, then open a trivial branch PR on `posit-dev/open-source-website`. Expect `build-and-deploy` runs via `pull_request`.
- [ ] Close and reopen #170 (Thomas's fork PR). Expect `notify-fork-pr` posts the sticky comment; no deploy runs.
- [ ] On #170, have a member comment `/deploy-preview`. Expect the `issue_comment` path runs `build-and-deploy` end-to-end.
- [ ] Close #193 (debug logging PR) — superseded by this change, which removes the debug job.