### PR TITLE
Post blog checklist comment on fork PRs

### DIFF
--- a/.github/workflows/blog-checklist.yml
+++ b/.github/workflows/blog-checklist.yml
@@ -1,7 +1,7 @@
 name: Blog Publishing Checklist
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
     paths:
       - 'content/blog/**'


### PR DESCRIPTION
## Summary

- Same fork-PR permission issue as [#194](https://github.com/posit-dev/open-source-website/pull/194), different workflow: the `Blog Publishing Checklist` job fails with `Resource not accessible by integration` when posting its comment (e.g. the checklist run on [#195](https://github.com/posit-dev/open-source-website/pull/195)).
- Switch the trigger from `pull_request` to `pull_request_target`. That gives the job a write-capable token on fork PRs and runs the workflow definition from `main`.
- Safe here because the workflow never checks out PR code, doesn't read PR content, and the comment body is entirely static — no untrusted input.

## Test plan

- [ ] After merge, open a fresh fork PR touching `content/blog/**` and confirm the checklist comment appears.
- [ ] Open a same-repo branch PR touching `content/blog/**` and confirm the checklist still appears (no regression).
- [ ] Re-open a PR that already has a checklist comment and confirm the dedupe check still prevents a duplicate.