### PR TITLE
Fix axe-core button-name violation on code-block copy buttons

### DIFF
--- a/assets/js/code-copy.js
+++ b/assets/js/code-copy.js
@@ -11,6 +11,7 @@
     const button = document.createElement("button");
     button.className = "right-1 top-1 absolute";
     button.type = "button";
+    button.setAttribute("aria-label", "Copy code");
     button.innerHTML = copyIcon;
     button.addEventListener("click", () => copyCodeToClipboard(button, highlightDiv));
     highlightDiv.insertBefore(button, highlightDiv.firstChild);

--- a/layouts/partials/extended_footer.html
+++ b/layouts/partials/extended_footer.html
@@ -19,12 +19,12 @@
 {{- if (findRE "<pre" .Content 1) }}
 <!-- hidden element for JS to get inner element and tailwind to output related CSS classes -->
 <div class="hidden top-1 right-1" id="code-copy">
-  <i class="h-6 w-6 block">
+  <i class="h-6 w-6 block" aria-hidden="true">
     {{ partial "icon.html" "copy" }}
   </i>
 </div>
 <div class="hidden top-1 right-1" id="code-copy-done">
-  <i class="h-6 w-6 block">
+  <i class="h-6 w-6 block" aria-hidden="true">
     {{ partial "icon.html" "check" }}
   </i>
 </div>


### PR DESCRIPTION
## Summary
- Adds `aria-label="Copy code"` to the copy-to-clipboard button emitted by `assets/js/code-copy.js` so screen readers announce its purpose.
- Adds `aria-hidden="true"` to the `<i>` wrappers around the copy/check SVG icons in `layouts/partials/extended_footer.html` so the icon doesn't get announced separately.

Closes #222

## Test plan
- [x] Verified locally with `hugo server` on a post containing code blocks — JS bundle includes the new attribute and rendered HTML shows `aria-hidden` on the icon wrappers.
- [x] Manually re-run axe-core on a blog post with code blocks to confirm the `button-name` violation is gone.