### PR TITLE
Improve dropdown menus: styling, mobile UX, and About dropdown

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -99,6 +99,8 @@
     } else if (navbarLangToggle.contains(target)) {
       closeMenu();
       navbarLang && navbarLang.classList.toggle('hidden');
+    } else if (target.closest('.dropdown-toggle') || target.closest('.dropdown-menu')) {
+      // Don't close the mobile menu when interacting with dropdowns
     } else {
       closeMenu();
       navbarLang && navbarLang.classList.add('hidden');
@@ -107,60 +109,87 @@
 
   // Dropdown menu handling
   document.addEventListener('DOMContentLoaded', function() {
-    const dropdowns = document.querySelectorAll('.dropdown-toggle');
+    function openDropdown(toggle, menu) {
+      menu.classList.remove('hidden');
+      toggle.setAttribute('aria-expanded', 'true');
+      var chevron = toggle.querySelector('.dropdown-chevron');
+      if (chevron) chevron.classList.add('rotate-180');
+      if (isMobile()) {
+        menu.style.maxHeight = menu.scrollHeight + 'px';
+      }
+    }
 
-    dropdowns.forEach(function(toggle) {
-      const menu = toggle.nextElementSibling;
-      const listItem = toggle.parentElement;
+    function closeDropdown(toggle, menu) {
+      toggle.setAttribute('aria-expanded', 'false');
+      var chevron = toggle.querySelector('.dropdown-chevron');
+      if (chevron) chevron.classList.remove('rotate-180');
+      if (isMobile()) {
+        menu.style.maxHeight = '0';
+        menu.addEventListener('transitionend', function handler() {
+          menu.classList.add('hidden');
+          menu.removeEventListener('transitionend', handler);
+        });
+      } else {
+        menu.classList.add('hidden');
+      }
+    }
+
+    function closeAllDropdowns(exceptMenu) {
+      document.querySelectorAll('.dropdown-toggle').forEach(function(otherToggle) {
+        var otherMenu = otherToggle.nextElementSibling;
+        if (otherMenu !== exceptMenu && otherToggle.getAttribute('aria-expanded') === 'true') {
+          closeDropdown(otherToggle, otherMenu);
+        }
+      });
+    }
+
+    document.querySelectorAll('.dropdown-toggle').forEach(function(toggle) {
+      var menu = toggle.nextElementSibling;
+      var listItem = toggle.parentElement;
 
       // Desktop: hover behavior
-      if (!isMobile()) {
-        listItem.addEventListener('mouseenter', function() {
-          menu.classList.remove('hidden');
-          toggle.setAttribute('aria-expanded', 'true');
-        });
+      listItem.addEventListener('mouseenter', function() {
+        if (!isMobile()) {
+          closeAllDropdowns(menu);
+          openDropdown(toggle, menu);
+        }
+      });
 
-        listItem.addEventListener('mouseleave', function() {
-          menu.classList.add('hidden');
-          toggle.setAttribute('aria-expanded', 'false');
-        });
-      }
+      listItem.addEventListener('mouseleave', function() {
+        if (!isMobile()) {
+          closeDropdown(toggle, menu);
+        }
+      });
 
-      // Mobile: click behavior
+      // Mobile: click/tap behavior
       toggle.addEventListener('click', function(e) {
         if (isMobile()) {
           e.preventDefault();
-          const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+          var isExpanded = toggle.getAttribute('aria-expanded') === 'true';
 
-          // Close all other dropdowns
-          document.querySelectorAll('.dropdown-menu').forEach(function(m) {
-            if (m !== menu) {
-              m.classList.add('hidden');
-              m.previousElementSibling.setAttribute('aria-expanded', 'false');
-            }
-          });
+          closeAllDropdowns(menu);
 
-          // Toggle this dropdown
           if (isExpanded) {
-            menu.classList.add('hidden');
-            toggle.setAttribute('aria-expanded', 'false');
+            closeDropdown(toggle, menu);
           } else {
-            menu.classList.remove('hidden');
-            toggle.setAttribute('aria-expanded', 'true');
+            openDropdown(toggle, menu);
           }
         }
       });
     });
 
     // Handle window resize
-    let lastMobileState = isMobile();
+    var lastMobileState = isMobile();
     window.addEventListener('resize', function() {
-      const currentMobileState = isMobile();
+      var currentMobileState = isMobile();
       if (lastMobileState !== currentMobileState) {
-        // Reset all dropdowns when switching between mobile/desktop
-        document.querySelectorAll('.dropdown-menu').forEach(function(menu) {
+        document.querySelectorAll('.dropdown-toggle').forEach(function(toggle) {
+          var menu = toggle.nextElementSibling;
           menu.classList.add('hidden');
-          menu.previousElementSibling.setAttribute('aria-expanded', 'false');
+          menu.style.maxHeight = '';
+          toggle.setAttribute('aria-expanded', 'false');
+          var chevron = toggle.querySelector('.dropdown-chevron');
+          if (chevron) chevron.classList.remove('rotate-180');
         });
         lastMobileState = currentMobileState;
       }

--- a/hugo.toml
+++ b/hugo.toml
@@ -87,19 +87,9 @@ inline = [['$', '$']]
     weight = 1
     parent = 'resources'
   [[menu.main]]
-    name = 'Tutorials'
-    url = '/resources/tutorials/'
-    weight = 2
-    parent = 'resources'
-  [[menu.main]]
     name = 'Videos'
     url = '/resources/videos/'
-    weight = 3
-    parent = 'resources'
-  [[menu.main]]
-    name = 'Webinars'
-    url = '/resources/webinars/'
-    weight = 4
+    weight = 2
     parent = 'resources'
   [[menu.main]]
     name = 'Blog'
@@ -109,3 +99,19 @@ inline = [['$', '$']]
     name = 'About'
     url = '/about/'
     weight = 7
+    identifier = 'about'
+  [[menu.main]]
+    name = 'About Posit'
+    url = '/about/posit/'
+    weight = 1
+    parent = 'about'
+  [[menu.main]]
+    name = 'Our R Work'
+    url = '/about/r/'
+    weight = 2
+    parent = 'about'
+  [[menu.main]]
+    name = 'Our Python Work'
+    url = '/about/python/'
+    weight = 3
+    parent = 'about'

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,7 +24,7 @@
   {{- if hugo.IsDevelopment }}
     {{ partial "tailwind-size-indicator.html" }}
   {{ end -}}
-  <header id="site-header" class="flex flex-none justify-center {{- if $.Site.Params.header.sticky }} sticky top-0{{ end -}} {{ if not .IsHome }}bg-white z-10{{ else }}transition-colors duration-300 z-50{{ end }}" data-is-home="{{ if .IsHome }}true{{ else }}false{{ end }}">
+  <header id="site-header" class="flex flex-none justify-center {{- if $.Site.Params.header.sticky }} sticky top-0{{ end -}} {{ if not .IsHome }}bg-white z-50{{ else }}transition-colors duration-300 z-50{{ end }}" data-is-home="{{ if .IsHome }}true{{ else }}false{{ end }}">
     {{ partial "header.html" . }}
   </header>
   <main class="flex flex-auto justify-center">

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -24,15 +24,15 @@
       {{- $isCurrent := or ($page.IsMenuCurrent .Menu .) ($page.HasMenuCurrent .Menu .) (and $page.IsHome (and .Page (eq
       $contentTypeName .Page.Type))) -}}
       {{ if .HasChildren }}
-      <li id="{{ .Identifier }}" class="relative group">
-        <button class="dropdown-toggle block text-center md:text-left text-2xl md:text-[0.9125rem] px-2 lg:px-3 py-5 md:py-3 font-mono font-medium uppercase hover:text-blue-500 {{- if $isCurrent }} text-green-600{{ end -}}"
+      <li id="{{ .Identifier }}" class="relative group w-full md:w-auto">
+        <button class="dropdown-toggle block w-full text-center md:text-left text-2xl md:text-[0.9125rem] px-2 lg:px-3 py-5 md:py-3 font-mono font-medium uppercase hover:text-blue-500 {{- if $isCurrent }} text-green-600{{ end -}}"
           aria-expanded="false" aria-haspopup="true">
-          {{ .Name }}<svg class="inline-block w-3 h-3 ml-1 align-middle -translate-y-0.25" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+          {{ .Name }}<svg class="dropdown-chevron inline-block w-3 h-3 ml-1 align-middle -translate-y-0.25 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
         </button>
-        <ul class="dropdown-menu hidden md:absolute md:left-0 md:mt-0 md:w-48 md:bg-white md:shadow md:rounded-xl md:py-2 md:z-50">
+        <ul class="dropdown-menu hidden md:absolute md:left-0 md:mt-0 md:w-40 md:bg-white md:shadow md:rounded-xl md:py-2 md:z-[60] overflow-hidden transition-[max-height] duration-300 ease-in-out max-h-0 md:max-h-none md:bottom-auto bottom-0">
           {{ range .Children }}
           <li>
-            <a class="block px-4 py-2 text-[0.825rem] font-medium uppercase font-mono text-center md:text-left hover:bg-blue-100 hover:text-gray-700"
+            <a class="block px-4 py-2 text-xl md:text-[0.825rem] font-medium uppercase font-mono text-center md:text-left hover:bg-blue-100 hover:text-gray-700"
               href="{{ .URL }}">{{ .Name }}</a>
           </li>
           {{ end }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -16,7 +16,7 @@
       {{ partial "icon.html" "x" }}
     </i>
   </button>
-  <div class="fixed md:static top-20 md:top-auto left-0 right-0 bottom-0 md:bottom-auto z-40 w-full h-0 md:h-auto md:w-auto md:opacity-100 md:visible transition-all duration-300 ease-in-out overflow-hidden md:overflow-visible" id="navbar-menu" style="transition-property: height, opacity;" data-is-home="{{ if $isHome }}true{{ else }}false{{ end }}">
+  <div class="fixed md:static top-20 md:top-auto left-0 right-0 bottom-0 md:bottom-auto z-[90] w-full h-0 md:h-auto md:w-auto md:opacity-100 md:visible transition-all duration-300 ease-in-out overflow-hidden md:overflow-visible" id="navbar-menu" style="transition-property: height, opacity;" data-is-home="{{ if $isHome }}true{{ else }}false{{ end }}">
     <div class="absolute inset-0 {{ if $isHome }}bg-yellow-50{{ else }}bg-white{{ end }} md:bg-transparent transition-colors duration-300" id="navbar-menu-bg"></div>
     <ul
       class="absolute top-4/9 -translate-y-1/2 left-0 right-0 flex flex-col mx-2 md:static md:top-auto md:translate-y-0 md:mx-0 md:flex-row md:items-center md:gap-x-0 md:border-0 text-base font-regular opacity-0 md:opacity-100 transition-opacity duration-300 md:bg-transparent md:shadow-none md:rounded-none md:border-0" id="navbar-menu-content">


### PR DESCRIPTION
## Summary

- Hide Tutorials and Webinars from Resources dropdown (pages are empty)
- Add About dropdown with children: About Posit, Our R Work, Our Python Work, AI Tools
- Fix z-index so dropdowns render above sticky filter controls
- Reduce dropdown width for a tighter look
- Improve mobile UX: tap to toggle with animated expand/collapse, chevron rotation, centered alignment
- Desktop keeps hover-to-open behavior

## Test plan

- [ ] Verify Resources dropdown shows only Cheatsheets and Videos
- [ ] Verify About dropdown shows all four sub-pages
- [ ] On desktop: hover opens/closes dropdowns, dropdown renders above page filters
- [ ] On mobile: tap toggles dropdown with smooth animation, menu doesn't close when tapping dropdown items, parent labels are centered