### PR TITLE
Blog authoring guide and skill tweaks

### DIFF
--- a/.claude/commands/check-post.md
+++ b/.claude/commands/check-post.md
@@ -32,7 +32,7 @@ If any `.qmd` files need rendering, warn the user and always offer to re-render 
 quarto render <path>/index.qmd
 ```
 
-Check `content/blog/_authoring-guide.md` for environment setup instructions — `.qmd` posts may need `uv run quarto render` (Python) or an `renv` environment (R).
+`.qmd` posts may need to render through a specific environment — check the post folder for a `pyproject.toml`, `renv.lock`, or similar, and use whatever tool the author set up. See the "Setting up an environment" section of `content/blog/_authoring-guide.md` for context.
 
 Do not proceed with validation until `index.md` exists and is up to date for all posts.
 
@@ -51,7 +51,7 @@ If all checks pass, say so and stop.
 If there are issues, summarize them clearly grouped by severity:
 
 - **Errors** need fixing before the post can be published.
-- **Warnings** are worth reviewing but won't block publishing.
+- **Warnings** are worth reviewing but won't block publishing — and some are reasonable to leave alone (see below).
 
 For each error, explain what's wrong and suggest a concrete fix. For example:
 
@@ -61,9 +61,24 @@ For each error, explain what's wrong and suggest a concrete fix. For example:
 - Missing `source` on a ported post → suggest setting it to match `ported_from`
 - `categories` present → replace with `topics`
 
+For warnings, distinguish two groups:
+
+**Sometimes intentional — ask before fixing.** These warnings flag fields that can be legitimately omitted when the post genuinely doesn't have that dimension:
+
+- **`software` missing** — may be intentional for general best-practices, community, or company-news posts that aren't about a specific project. Ask before suggesting a value.
+- **`languages` missing** — may be intentional for posts that aren't about a particular programming language. Ask before suggesting a value.
+- **Can't find people page for `<name>`** — may be intentional if the contributor doesn't want a `content/people/` profile. Ask before offering to create one.
+
+**Should normally be acted on.**
+
+- **`date` is in the past** — confirm whether the author wants the post to publish on merge; if not, suggest a future date.
+- **`<name>` looks like a team name** — suggest replacing with the individual contributors.
+
 ## Step 5: Offer to fix
 
-Ask the user if they'd like you to fix the errors directly. If yes:
+For errors and the "should normally be acted on" warnings, ask the user if they'd like you to fix them directly. For the "sometimes intentional" warnings, ask first whether the absence is intentional — only fix if the user confirms a value should be set.
+
+If they accept any fixes:
 
 - If the post has an `index.qmd`, edit the **`.qmd`** file (that's the source of truth), then re-render to update `index.md`.
 - If the post is plain Markdown, edit `index.md` directly.

--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -82,13 +82,37 @@ Edit the created file to replace the archetype defaults with the confirmed value
 
 ## Step 6: Open the file
 
-Report the full path to the created file so the user can open it themselves.
+Report the full path to the created file so the user can open it themselves, along with the predicted permalink the post will live at: `/blog/<date>_<slug-or-folder>/` (e.g. `/blog/2026-04-07_my-post/`).
 
-## Step 7: Provide a checklist
+## Step 7: Offer to set up local preview
 
-Finish by giving the author this checklist:
+Local preview is recommended for fast iteration but optional — the author can also rely on the Netlify preview that gets built on the PR. Mention this up front, then offer the local-preview setup as something they can opt into.
 
-- [ ] Review the inferred frontmatter — correct `topics`, `software`, `languages` if needed
-- [ ] Add `image` (1920×1080 PNG or JPG recommended) and `image-alt`
-- [ ] Your post will be live at `/blog/<date>_<folder-name>/` — e.g. `/blog/2026-04-07_my-post/` (date from frontmatter, folder name as slug)
-- [ ] Preview: open a PR against `main` for a Netlify preview, or run `just dev` locally (see `content/blog/_authoring-guide.md` for setup)
+Detect which preview tools the user already has on `PATH`:
+
+```sh
+for t in just hugo node quarto; do command -v "$t" >/dev/null 2>&1 && echo "$t: present" || echo "$t: missing"; done
+```
+
+For any that are missing, list them and offer to install them. Don't run the install yourself unprompted — the author may prefer their own setup.
+
+- macOS: `brew install just`, `brew install hugo node`; install Quarto from [quarto.org](https://quarto.org/docs/get-started/)
+- Other platforms: point at the [Prerequisites](../../README.md#prerequisites) section of the README
+
+If `node_modules/` doesn't exist at the repo root, offer to run `just install` to pick up the Node dependencies.
+
+Then offer to start a local preview in the background:
+
+- `just dev` for Hugo + Tailwind
+- For `.qmd` posts, additionally offer `quarto preview index.qmd` from the post directory so Quarto re-renders on save while Hugo live-reloads
+
+Skip any of these if the author declines or already has a preview running.
+
+## Step 8: Hand off
+
+Finish with a short next-steps list:
+
+- Add `image` (1920×1080 PNG or JPG recommended) and `image-alt` to the frontmatter.
+- Once frontmatter is filled in, run `/check-post` to validate it.
+- Once the draft is ready, run `/review-post` for a content review before opening a PR.
+- Open a PR against `main` to get a Netlify preview and a human review.

--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -80,44 +80,15 @@ Edit the created file to replace the archetype defaults with the confirmed value
 - Remove empty `tags` entries
 - Leave `image` and `image-alt` empty for the author to fill in
 
-## Step 6: Set up an environment (`.qmd` posts only)
-
-**Python only:**
-
-Description: "Setting up a per-post Python environment so package versions are recorded alongside the post"
-
-```sh
-uv init --no-workspace
-```
-Then ask which packages are needed and `uv add` them.
-
-**R only:**
-
-Description: "Setting up a per-post R environment so package versions are recorded alongside the post"
-
-```sh
-Rscript -e "renv::init()"
-```
-
-**Both R and Python:**
-
-Description: "Setting up a per-post R environment with reticulate so both R and Python packages are recorded"
-
-```sh
-Rscript -e "renv::init()"
-Rscript -e "renv::install('reticulate')"
-```
-
-## Step 7: Open the file
+## Step 6: Open the file
 
 Report the full path to the created file so the user can open it themselves.
 
-## Step 8: Provide a checklist
+## Step 7: Provide a checklist
 
 Finish by giving the author this checklist:
 
 - [ ] Review the inferred frontmatter — correct `topics`, `software`, `languages` if needed
 - [ ] Add `image` (1920×1080 PNG or JPG recommended) and `image-alt`
-- [ ] *(`.qmd` with R)* Install packages then run `renv::snapshot()` to lock the environment
 - [ ] Your post will be live at `/blog/<date>_<folder-name>/` — e.g. `/blog/2026-04-07_my-post/` (date from frontmatter, folder name as slug)
 - [ ] Preview: open a PR against `main` for a Netlify preview, or run `just dev` locally (see `content/blog/_authoring-guide.md` for setup)

--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -38,7 +38,7 @@ From the title and topic, reason about:
 - **software** — folder names from `content/software/` that the post is about (e.g. `ggplot2`, `quarto`, `great-tables`)
 - **languages** — programming languages featured (R, Python, etc.)
 - **topics** — one or more from the fixed set in `data/topics.yaml`: Machine Learning, Artificial Intelligence, Visualization, Interactive Apps, Publishing, MLOps and Admin, Data Wrangling, Best Practices, Community
-- **source** — only needed if the post should appear on a legacy blog's listing page (e.g. `/blog/q/tidyverse/`). Valid values: `positron`, `tidyverse`, `ai`, `shiny`, `great_tables`, `plotnine`, `pointblank`, `quarto`. Many new posts won't need this — ask the user about it if the topic could be related to a legacy blog.
+- **source** — set if the post belongs to one of the projects with its own blog listing page, so it appears there (e.g. `source: tidyverse` → `/blog/q/tidyverse/`). Older project blog URLs (e.g. `tidyverse.org/blog/`) redirect to these listing pages, so this is how a new post stays visible to those readers. Valid values: `positron`, `tidyverse`, `ai`, `shiny`, `great_tables`, `plotnine`, `pointblank`, `quarto`. Infer from the inferred `software`/topic (e.g. dplyr/ggplot2 → `tidyverse`, Positron → `positron`); confirm with the user. Omit only if the post genuinely doesn't belong to any of these projects.
 - **description** — a draft 1–2 sentence description of the post
 
 Present your inferences clearly and ask the user to confirm or correct before proceeding.

--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -88,11 +88,14 @@ Report the full path to the created file so the user can open it themselves, alo
 
 Local preview is recommended for fast iteration but optional — the author can also rely on the Netlify preview that gets built on the PR. Mention this up front, then offer the local-preview setup as something they can opt into.
 
-Detect which preview tools the user already has on `PATH`:
+Detect which preview tools the user already has on `PATH`. Run four separate `command -v` checks — issue them as parallel Bash calls so each is a single-command invocation the permission system can auto-allow (compound statements with loops or `&&`/`||` won't statically analyze):
 
-```sh
-for t in just hugo node quarto; do command -v "$t" >/dev/null 2>&1 && echo "$t: present" || echo "$t: missing"; done
-```
+- `command -v just`
+- `command -v hugo`
+- `command -v node`
+- `command -v quarto`
+
+A zero exit code (and a printed path) means the tool is present; non-zero means it's missing.
 
 For any that are missing, list them and offer to install them. Don't run the install yourself unprompted — the author may prefer their own setup.
 

--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -26,9 +26,7 @@ Ask the user for anything not already provided via arguments: `$ARGUMENTS`
 - **Title** — the post title
 - **Topic** — a brief description of what the post is about (use this to infer frontmatter)
 - **Author(s)** — full name(s) of the people writing the post
-- **Executable code?** — ask "Will this post include executable code chunks (R or Python)?" rather than asking about file format directly:
-  - Yes → `.qmd`; also ask whether the code is R, Python, or both
-  - No → `.md` (unless they specifically want `.ipynb`, which is fine to offer)
+- **Format** — default to `.qmd`. It supports executable code *and* Quarto features (tabsets, callouts, multi-column layouts), so it's the right choice for most posts. Use `.md` only when the post is straight prose with no code blocks and none of those Quarto features. Offer `.ipynb` if the user prefers writing in Jupyter. For `.qmd` posts that will execute code, also ask whether it's R, Python, or both.
 
 ## Step 2: Infer frontmatter
 

--- a/.claude/commands/review-post.md
+++ b/.claude/commands/review-post.md
@@ -1,0 +1,79 @@
+---
+name: review-post
+description: Review a blog post's content against its frontmatter and the authoring guide
+---
+
+Review a blog post's content the way a reviewer would — checking that the content lines up with its frontmatter, surfacing things authors commonly miss, and flagging accessibility issues. Complements `/check-post`, which validates frontmatter mechanically; this skill reads the actual post text.
+
+This skill **does not check writing style**. At the end, remind the author to get a human review for tone, clarity, and flow.
+
+## Step 1: Identify the post
+
+If the user provided a path via `$ARGUMENTS`, use that. Otherwise, look for blog posts changed on the current branch:
+
+```sh
+git diff --name-only --diff-filter=d origin/main...HEAD -- 'content/blog/**/index.md' 'content/blog/**/index.qmd'
+```
+
+If no changed posts are found, ask the user which post to review.
+
+## Step 2: Read the post
+
+For each post, read both the frontmatter and the body. If an `index.qmd` exists, prefer it as the source of truth; otherwise read `index.md`. You need the actual prose, not just the metadata.
+
+## Step 3: Content vs. frontmatter consistency
+
+Compare what the post actually says to what its frontmatter claims. Flag mismatches:
+
+- **`description` drift** — does the description still summarize the post accurately? Descriptions written at `/new-post` time often stop matching the finished draft.
+- **`software` / `languages` / `topics`** — do the values reflect what the post is actually about? If the post discusses ggplot2 but `software` only lists dplyr, flag it. If the inferred topics no longer fit, flag it. Suggest the values that *would* match.
+- **`source`** — if the post is clearly about one of the projects with a blog listing page (`positron`, `tidyverse`, `ai`, `shiny`, `great_tables`, `plotnine`, `pointblank`, `quarto`) and `source` isn't set, flag it. See `content/blog/_authoring-guide.md` for the rule.
+- **`title`** — does it match the post's actual focus, or has the angle shifted during writing?
+
+## Step 4: Things authors miss
+
+- **Placeholders left in the draft** — search the body for `TODO`, `TBD`, `XXX`, `FIXME`, `lorem ipsum`, `[insert ...]`, `[link]`, etc. List each occurrence with line context.
+- **Internal blog links use the permalink pattern** — flag any links that look like `/blog/<source>/<year>/<slug>/` or other content-directory paths instead of `/blog/YYYY-MM-DD_slug/`. (See "Linking to other blog posts" in the authoring guide.)
+- **Code blocks have a language tag** — fenced code blocks should open with a language (` ```r `, ` ```python `, ` ```sh `, etc.), not bare ` ``` `.
+- **`.qmd` images use `fig-alt`** — alt text in `.qmd` should be `![](path){fig-alt="..."}`, not `![alt](path)` (the bracket text becomes a caption in Quarto).
+
+## Step 5: Accessibility and structure
+
+- **Image alt text on body images** — for every image in the post body, check that alt text is descriptive ("Bar chart showing ...") not generic ("screenshot", "logo", "image"). Empty alt is only acceptable for purely decorative images.
+- **Heading hierarchy** — the post body should have **no `#` (H1) headings** — the page H1 is rendered from frontmatter `title`. Top-level body sections should start at `##` (H2), and lower-level headings shouldn't skip levels (don't jump `##` → `####`).
+
+## Step 6: Predicted permalink
+
+From the frontmatter `date` and `slug` (or folder name), report the URL the post will live at:
+
+```
+/blog/{date}_{slug-or-folder}/
+```
+
+This lets the author sanity-check the slug before publishing and copy the URL for cross-linking from other posts.
+
+## Step 7: Report findings
+
+Summarize results grouped by severity:
+
+- **Must fix** — placeholders, broken permalink-format links, missing code-block languages, generic/missing alt text, bracket-alt on `.qmd` images, heading hierarchy violations.
+- **Consider** — frontmatter drift (`description`, `software`, `languages`, `topics`, `source`, `title`), title-vs-content focus shifts.
+
+For each item, quote the relevant line(s) and explain what to change.
+
+If there are no findings, say so.
+
+## Step 8: Offer to fix
+
+Ask whether to apply the fixes. For accepted items:
+
+- If the post has an `index.qmd`, edit the `.qmd` (source of truth), then re-render to update `index.md`.
+- Otherwise, edit `index.md` directly.
+
+## Step 9: Re-run /check-post
+
+After any frontmatter edits, run `/check-post` (or the underlying script) on the post so the author sees a clean mechanical-validation pass before moving on.
+
+## Step 10: Remind about human review
+
+Finish with a one-line reminder: this skill doesn't check writing style, tone, or flow — ask a teammate to read the draft before merging.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,24 @@ Custom Hugo taxonomies for organizing content:
 - **Node.js** v20 or higher
 - **Hugo Extended** v0.153.2 or higher
 - **Quarto** (for rendering .qmd and .ipynb files)
-- **UV** (Python package manager) - `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- **UV** (Python package manager)
 - **Python** 3.8+ (for automation scripts)
+
+On macOS, install via Homebrew (Homebrew's `hugo` formula is the extended build):
+
+```sh
+brew install just              # command runner — used to run `just dev`, `just build`, etc.
+brew install hugo node         # Hugo Extended + Node.js
+curl -LsSf https://astral.sh/uv/install.sh | sh    # uv
+```
+
+Install Quarto from [quarto.org](https://quarto.org/docs/get-started/) (only needed if rendering `.qmd` or `.ipynb`).
+
+For other platforms, see each tool's docs:
+[just](https://github.com/casey/just#installation),
+[Node.js](https://nodejs.org/),
+[Hugo](https://gohugo.io/installation/),
+[uv](https://docs.astral.sh/uv/getting-started/installation/).
 
 ### Installation
 

--- a/content/blog/CLAUDE.md
+++ b/content/blog/CLAUDE.md
@@ -64,11 +64,11 @@ Freeform. Avoid duplicating `software` or `topics` values.
 | `photo.url` / `photo.author` | Stock photo attribution |
 | `code-line-numbers` | Boolean, turns on line-number gutters for every code block on the page |
 
-## Legacy Blog Listing
+## Project Blog Listing
 
 | Field | Purpose |
 |-------|---------|
-| `source` | Legacy blog this post should appear on: `positron`, `tidyverse`, `ai`, `shiny`, `great_tables`, `plotnine`, `pointblank`, `quarto`, `education`, `rstudio`. Drives inclusion on legacy blog landing pages (e.g. `/blog/tidyverse/`). Required for all ported posts (must match `ported_from`). Optional for new posts — only add if the post should appear on a legacy blog's listing page. |
+| `source` | Project blog this post belongs to. Drives inclusion on the project blog listing pages (e.g. `/blog/q/tidyverse/`) — older project blog URLs (e.g. `tidyverse.org/blog/`) redirect there, so a new post about one of these projects should set `source` to keep appearing for those readers. Required for all ported posts (must match `ported_from`; full set: `positron`, `tidyverse`, `ai`, `shiny`, `great_tables`, `plotnine`, `pointblank`, `quarto`, `education`, `rstudio`). New posts use the actively published subset: `positron`, `tidyverse`, `ai`, `shiny`, `great_tables`, `plotnine`, `pointblank`, `quarto`. (`education` and `rstudio` are reserved for ported posts.) |
 
 ## Porting Metadata
 

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -199,6 +199,10 @@ The other warnings should normally be acted on:
 
 ### `.qmd` posts
 
+#### Headings
+
+The page H1 is rendered from frontmatter `title`, so the post body should not contain any `#` (H1) headings. Start top-level body sections at `##` (H2), and don't skip levels (don't jump `##` → `####`).
+
 #### Tabsets
 
 ```markdown
@@ -300,6 +304,10 @@ Don't use content directory paths like `/blog/tidyverse/2020/dplyr-1-0-0/`. Thos
 To find a post's permalink, check its `date` and `slug` (or folder name) in frontmatter. The pattern is `/blog/{date}_{slug}/`, e.g. `date: 2020-06-01` + `slug: dplyr-1-0-0` → `/blog/2020-06-01_dplyr-1-0-0/`. Or just find the post on the site and copy the URL.
 
 ### `.md` posts
+
+#### Headings
+
+The page H1 is rendered from frontmatter `title`, so the post body should not contain any `#` (H1) headings. Start top-level body sections at `##` (H2), and don't skip levels (don't jump `##` → `####`).
 
 #### Code line numbers
 

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -84,17 +84,19 @@ The URL slug defaults to the folder name, so you only need to set `slug` in fron
 
 ### Option 2: Build locally
 
-For faster iteration, you can preview locally. You'll need:
-
-- [just](https://github.com/casey/just)
-- Node.js v20+
-- Hugo Extended v0.158.0+
-- Quarto (if rendering `.qmd` or `.ipynb` files)
-
-First-time setup:
+For faster iteration, you can preview locally. You'll need [just](https://github.com/casey/just), Node.js v20+, Hugo Extended v0.158.0+, and Quarto (if rendering `.qmd` or `.ipynb` files). On macOS:
 
 ```sh
-just install   # Install Node.js dependencies
+brew install just         # command runner — needed for `just dev`
+brew install hugo node    # Hugo Extended + Node.js
+```
+
+Install Quarto from [quarto.org](https://quarto.org/docs/get-started/) if rendering `.qmd` or `.ipynb`. See [Prerequisites](../../README.md#prerequisites) in the README for other platforms.
+
+First-time setup (Node dependencies):
+
+```sh
+just install
 ```
 
 Then start the dev server:

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -24,11 +24,11 @@ For a Quarto post, create as `index.md` then rename to `index.qmd` — Hugo does
 
 ## Choosing a format
 
-- **`index.md`** — prose only; no code execution needed
-- **`index.qmd`** — executable R or Python code, or Quarto features like callouts, tabsets, and cross-references.
-- **`index.ipynb`** — if you're primarily working in Jupyter
+- **`index.qmd`** — recommended default. Supports executable R or Python code plus Quarto features like callouts, tabsets, and multi-column layouts. Renders to `index.md` for Hugo to build.
+- **`index.md`** — straight prose only; no code execution and no Quarto features needed.
+- **`index.ipynb`** — if you're primarily working in Jupyter.
 
-When in doubt, use `.md`.
+When in doubt, use `.qmd`.
 
 ## Frontmatter
 

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -37,7 +37,7 @@ See `CLAUDE.md` in this directory for the full metadata schema. A few things wor
 - **Authors** — use `people`, not `author`. List individuals by full name; don't use team names like "Shiny Team"
 - **Image** — 1920×1080 PNG or JPG recommended (16:9); GIF is supported and animation will play in the hero and listings
 - **Alt text** — describe what the image shows; "screenshot" or "logo" alone isn't enough
-- **Legacy blog listing** — if your post should appear on a legacy blog's listing page (e.g. `/blog/tidyverse/`), add `source: tidyverse`. Valid values: `positron`, `tidyverse`, `ai`, `shiny`, `great_tables`, `plotnine`, `pointblank`, `quarto`, `education`, `rstudio`. Most new posts won't need this.
+- **Project blog listing** — if your post belongs to one of the projects below, set `source` so it appears on that project's blog listing page (e.g. `source: tidyverse` → `/blog/q/tidyverse/`). Older project blog URLs (e.g. `tidyverse.org/blog/`) will redirect to these listing pages, so posts about these projects should set `source` to stay visible to those readers. Valid values for new posts: `positron`, `tidyverse`, `ai`, `shiny`, `great_tables`, `plotnine`, `pointblank`, `quarto`. (`education` and `rstudio` are reserved for ported posts — those blogs aren't actively published to.)
 
 ## Setting up an environment
 

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -182,6 +182,19 @@ Other flags:
 
 The `/check-post` skill runs validation interactively and can offer to fix issues it finds.
 
+### When warnings are OK to ignore
+
+A few warnings flag situations where the value can be omitted (or left mismatched) when the post genuinely warrants it:
+
+- **`software` missing** — fine if the post isn't about a specific project (e.g. general best-practices, company news, or community posts). Set it whenever the post focuses on one or more projects from `content/software/`.
+- **`languages` missing** — fine if the post isn't about a particular programming language. Set it whenever the post features code in R, Python, etc.
+- **Can't find people page for `<name>`** — fine if the contributor doesn't want their own `content/people/` profile. Otherwise, add one at `content/people/<slug>/_index.md` before merging.
+
+The other warnings should normally be acted on:
+
+- **`date` is in the past** — only leave it if you really do want the post to publish on merge.
+- **`<name>` looks like a team name** — replace with the individual contributors.
+
 ## Content reference
 
 ### `.qmd` posts

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -118,7 +118,23 @@ This runs Hugo and the Tailwind CSS watcher in parallel. The site will be availa
   quarto preview index.qmd
   ```
 
-## Getting published
+## Reviewing your post
+
+Before opening a PR, give your draft a once-over for content issues that mechanical frontmatter validation can't catch.
+
+The `/review-post` skill reads the post body and flags:
+
+- Content-vs-frontmatter drift (e.g. `description` no longer matching the finished draft, `software` / `languages` / `topics` out of date, missing `source`)
+- Placeholders left in the body (`TODO`, `TBD`, `[insert link]`, lorem ipsum)
+- Internal blog links not using the `/blog/YYYY-MM-DD_slug/` permalink pattern
+- Code blocks missing a language tag
+- Body image alt text and heading hierarchy
+
+It re-runs `/check-post` at the end, so it covers frontmatter validation too.
+
+The skill **does not** check writing style, tone, or flow. Get a human reviewer for that as part of the PR — see [Publishing your post](#publishing-your-post) below.
+
+## Publishing your post
 
 Once your post is written, follow these steps to get it live.
 
@@ -290,6 +306,18 @@ Right column content.
 ```
 
 A Lua filter converts these to CSS grid at render time, so code blocks (including those with `filename=` attributes) render correctly.
+
+#### Raw HTML
+
+Quarto sends your `.qmd` through Pandoc, which parses inline HTML and can rewrite attributes, strip elements, or wrap things in extra `<p>` tags. When you need to drop in HTML and have it survive Pandoc untouched — embeds, iframes, custom widgets, hand-rolled layouts — wrap it in a raw HTML block:
+
+````markdown
+```{=html}
+<div class="custom-thing">
+  <p>Passed through to the rendered output exactly as written.</p>
+</div>
+```
+````
 
 #### Linking to other blog posts
 

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -41,43 +41,18 @@ See `CLAUDE.md` in this directory for the full metadata schema. A few things wor
 
 ## Setting up an environment
 
-For `.qmd` posts with executable code, record the environment in the post's folder so others can reproduce it.
+For `.qmd` posts with executable code, you may want to record the environment in the post's folder so others can reproduce it later. This is optional — pick the approach that fits how you usually work, including not pinning at all.
 
-### Python (uv)
+Common options:
 
-```sh
-cd content/blog/my-post/
-uv init --no-workspace
-uv add package1 package2
-```
+- **Python** — `uv` or a plain `requirements.txt`
+- **R** — `renv` or a `DESCRIPTION` file with `pak`
 
-Optionally pin dependency resolution to a date for long-term reproducibility:
+If you do pin:
 
-```toml
-[tool.uv]
-exclude-newer = "2025-01-01T00:00:00Z"
-```
-
-Commit `pyproject.toml` and `uv.lock`. The `.venv/` folder is gitignored.
-
-Render using the environment:
-
-```sh
-uv run quarto render index.qmd
-```
-
-### R (renv)
-
-```r
-# With your R working directory set to the post folder
-renv::init()
-# install packages, write your post...
-renv::snapshot()
-```
-
-Commit `renv.lock`, `.Rprofile`, `renv/activate.R`, and `renv/settings.json`. The `renv/library/` folder is gitignored.
-
-If you prefer, a `DESCRIPTION` file with `pak` for dependency declaration also works, though it's less established for posts.
+- Commit the environment definition and lockfile(s) (e.g. `pyproject.toml` + `uv.lock`, or `renv.lock` + `.Rprofile` + `renv/activate.R` + `renv/settings.json`) alongside the post.
+- Don't commit the package library or virtual environment — `.venv/` and `renv/library/` are gitignored.
+- Render the post from within the environment (e.g. `uv run quarto render index.qmd`, or with `renv` activated).
 
 ## Rendering and committing
 


### PR DESCRIPTION
## Summary

Updates to the blog authoring workflow — both the human-facing guide and the Claude Code skills.

**Authoring guide (`content/blog/_authoring-guide.md`)**
- Reframe `source` as the "project blog listing" field, not "legacy blog"; clarify when new posts should set it.
- Make environment management optional and tool-agnostic (was prescriptive uv/renv).
- Add a "Reviewing your post" section and rename "Getting published" → "Publishing your post" for a consistent four-section workflow.
- Add a "When warnings are OK to ignore" subsection covering `software` / `languages` / missing people-page warnings vs warnings that should be acted on.
- Add `#### Headings` (no `#` in body — title becomes H1) and `#### Raw HTML` (wrap in `{=html}` so Pandoc doesn't rewrite it) reference sections.
- Default to `.qmd` instead of `.md` — `.qmd` supports Quarto features (tabsets, callouts, multi-column) that prose-heavy posts sometimes want.

**README**
- Add macOS Homebrew install commands for `just`, `hugo`, `node`, `uv`, plus per-tool docs links for other platforms. Quarto points at quarto.org (not Homebrew).

**Skills**
- New `/review-post` skill: reads post content and flags content↔frontmatter drift, placeholders, internal-link permalink format, code-block language tags, body image alt text, and heading hierarchy. Re-runs `/check-post` at the end. Explicitly doesn't check writing style.
- `/check-post` updated to distinguish "sometimes intentional" warnings from "act on these" warnings and ask before fixing the former.
- `/new-post` updated: defaults to `.qmd`, drops the prescriptive uv/renv setup step, reports the predicted permalink, offers preview-tool detection + install (using parallel `command -v` calls so the permission system can auto-allow), and hands off with pointers to `/check-post` and `/review-post`.

Closes #163.

## Test plan

- [x] `/new-post` end-to-end on a `.qmd` post: confirms the new format prompt, environment step is gone, predicted permalink is shown, tool detection runs without permission prompts, hand-off list points at `/check-post` / `/review-post`.
- [ ] `/check-post` on a post missing `software` or `languages`: confirms it asks whether the absence is intentional rather than auto-suggesting a value.
- [x] `/review-post` on a draft with frontmatter drift and a placeholder in the body: confirms findings are grouped Must fix / Consider and that it re-runs `/check-post` at the end.
- [x] Skim the authoring guide for the new sections rendering cleanly on the GitHub preview.