### PR TITLE
Add legacy redirect audit script and supporting fixes

### DIFF
--- a/content/blog/anscombes-quartet/index.md
+++ b/content/blog/anscombes-quartet/index.md
@@ -7,9 +7,7 @@ people:
 date: '2024-07-02'
 image: ruthson-zimmerman-FVwG5OzPuzo-unsplash.jpg
 image-alt: Hands typing on a laptop showing a data dashboard on the screen
-ported_from: plotnine
 source: plotnine
-port_status: in-progress
 topics:
   - Visualization
 software: ["plotnine"]

--- a/scripts/extract-blog-metadata.R
+++ b/scripts/extract-blog-metadata.R
@@ -7,11 +7,11 @@ library(jsonlite)
 posts_dir <- "content/blog"
 source_extensions <- c(".qmd", ".Rmd", ".Rmarkdown", ".ipynb")
 
-# Find all index.md files in blog post directories
+# Find all published blog post files (.md, .markdown, or .html with frontmatter)
 md_files <- list.files(
 
   posts_dir,
-  pattern = "^index\\.(md|markdown)$",
+  pattern = "^index\\.(md|markdown|html)$",
 
   recursive = TRUE,
   full.names = TRUE


### PR DESCRIPTION
## Summary

Two small fixes supporting the legacy-blog-redirects work shared via issues on the seven legacy site repos:

- **Drop incorrect `ported_from` from anscombes-quartet** — the post was originally hosted externally (jeroenjanssens.com), not plotnine.org, so the porting metadata was misleading. Keeps `source: plotnine` so it still appears on the plotnine project listing.

- **Pick up `.html` posts in blog metadata extractor** — `scripts/extract-blog-metadata.R` now also matches `index.html`. Some hugodown-rendered tidyverse posts publish as `.html` rather than `.md`, and they were previously invisible to `posts.json` (and anything that consumes it).

