### PR TITLE
Update landing banner to Quarto project blog listing

### DIFF
--- a/content/blog/q/quarto/_index.md
+++ b/content/blog/q/quarto/_index.md
@@ -4,4 +4,4 @@ title: Quarto
 
 ### The Quarto blog has a new home
 
-The Quarto blog has moved to the [Posit Open Source blog](/blog/). All past and future Quarto posts now live here alongside posts from our other open-source projects.
+The Quarto blog has moved to the Posit Open Source blog. All past and future Quarto posts now live here alongside posts from our other open-source projects. Quarto's documentation, including the Guide, Reference, Gallery, and download pages, remains at [quarto.org](http://quarto.org).


### PR DESCRIPTION
## Summary

- Readers arriving at `/blog/q/quarto/` from quarto.org need orientation: blog posts have moved here, but documentation (Guide, Reference, Gallery, downloads) remains at quarto.org.
- Adds a short banner above the post listing with both pointers.
