### PR TITLE
Tell /new-post to scaffold posts at the top level

### DIFF
--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -53,6 +53,8 @@ git checkout -b blog/<slug>
 
 ## Step 4: Scaffold the post
 
+New posts go at the top level: `content/blog/<slug>/`. The subfolders (`tidyverse/`, `shiny/`, `quarto/`, `ai/`, etc.) are reserved for ported legacy content — never scaffold a new post into one, even if `source` is set. The `source` frontmatter field controls which project blog listing the post appears on; it does not affect folder placement.
+
 Description: "Scaffolding the post folder and frontmatter from the blog archetype"
 
 ```sh
@@ -64,7 +66,7 @@ If the format is `.qmd`, rename the file:
 Description: "Renaming to .qmd so Quarto will render this post to Markdown before Hugo builds it"
 
 ```sh
-mv content/blog/<path>/index.md content/blog/<path>/index.qmd
+mv content/blog/<slug>/index.md content/blog/<slug>/index.qmd
 ```
 
 ## Step 5: Fill in the frontmatter


### PR DESCRIPTION
## Summary

- Authors reported the `/new-post` skill scaffolding posts into project subfolders like `content/blog/tidyverse/`, which are reserved for ported legacy content.
- Step 4 now opens with the placement rule, calls out that `source` controls which project blog listing the post appears on (not folder placement), and uses `<slug>` consistently in the `mv` command (was `<path>`).

## Test plan

- [ ] Re-read Step 4 of `.claude/commands/new-post.md` and confirm the placement guidance reads clearly.