### PR TITLE
Back-tag blog posts with software added in #216 (and torch)

### DIFF
--- a/content/blog/ai/2020-04-21-sparklyr-1.2.0-released/index.Rmd
+++ b/content/blog/ai/2020-04-21-sparklyr-1.2.0-released/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - MLOps and Admin
 preview: images/sparklyr.png
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2020-04-21-sparklyr-1.2.0-released/index.md
+++ b/content/blog/ai/2020-04-21-sparklyr-1.2.0-released/index.md
@@ -17,6 +17,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2020-07-16-sparklyr-1.3.0-released/index.Rmd
+++ b/content/blog/ai/2020-07-16-sparklyr-1.3.0-released/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - MLOps and Admin
 preview: images/sparklyr-1.3.jpg
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages/Releases

--- a/content/blog/ai/2020-07-16-sparklyr-1.3.0-released/index.md
+++ b/content/blog/ai/2020-07-16-sparklyr-1.3.0-released/index.md
@@ -17,6 +17,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages/Releases

--- a/content/blog/ai/2020-07-29-parallelized-sampling/index.Rmd
+++ b/content/blog/ai/2020-07-29-parallelized-sampling/index.Rmd
@@ -14,6 +14,7 @@ categories:
 preview: images/dice.jpg
 header-includes: \usepackage{algorithm2e}
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Concepts

--- a/content/blog/ai/2020-07-29-parallelized-sampling/index.md
+++ b/content/blog/ai/2020-07-29-parallelized-sampling/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Concepts

--- a/content/blog/ai/2020-09-07-sparklyr-flint/index.Rmd
+++ b/content/blog/ai/2020-09-07-sparklyr-flint/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/thumb.png
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2020-09-07-sparklyr-flint/index.md
+++ b/content/blog/ai/2020-09-07-sparklyr-flint/index.md
@@ -16,6 +16,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2020-09-29-introducing-torch-for-r/index.Rmd
+++ b/content/blog/ai/2020-09-29-introducing-torch-for-r/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Machine Learning
 preview: images/pt.png
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Packages/Releases

--- a/content/blog/ai/2020-09-29-introducing-torch-for-r/index.md
+++ b/content/blog/ai/2020-09-29-introducing-torch-for-r/index.md
@@ -16,6 +16,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Packages/Releases

--- a/content/blog/ai/2020-09-30-sparklyr-1.4.0-released/index.Rmd
+++ b/content/blog/ai/2020-09-30-sparklyr-1.4.0-released/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - MLOps and Admin
 preview: images/sparklyr-1.4.jpg
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2020-09-30-sparklyr-1.4.0-released/index.md
+++ b/content/blog/ai/2020-09-30-sparklyr-1.4.0-released/index.md
@@ -17,6 +17,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2020-10-01-torch-network-from-scratch/index.Rmd
+++ b/content/blog/ai/2020-10-01-torch-network-from-scratch/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/pic.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-10-01-torch-network-from-scratch/index.md
+++ b/content/blog/ai/2020-10-01-torch-network-from-scratch/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-10-05-torch-network-with-autograd/index.Rmd
+++ b/content/blog/ai/2020-10-05-torch-network-with-autograd/index.Rmd
@@ -15,6 +15,7 @@ editor_options:
   markdown:
     wrap: 72
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-10-05-torch-network-with-autograd/index.md
+++ b/content/blog/ai/2020-10-05-torch-network-with-autograd/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-10-07-torch-modules/index.Rmd
+++ b/content/blog/ai/2020-10-07-torch-modules/index.Rmd
@@ -16,6 +16,7 @@ editor_options:
   markdown:
     wrap: 72
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-10-07-torch-modules/index.md
+++ b/content/blog/ai/2020-10-07-torch-modules/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-10-09-torch-optim/index.Rmd
+++ b/content/blog/ai/2020-10-09-torch-optim/index.Rmd
@@ -13,6 +13,7 @@ categories:
 bibliography: bibliography.bib
 preview: images/preview.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-10-09-torch-optim/index.md
+++ b/content/blog/ai/2020-10-09-torch-optim/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-10-12-sparklyr-flint-0.2.0-released/index.Rmd
+++ b/content/blog/ai/2020-10-12-sparklyr-flint-0.2.0-released/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Machine Learning
 preview: images/sparklyr-flint-0.2.jpg
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2020-10-12-sparklyr-flint-0.2.0-released/index.md
+++ b/content/blog/ai/2020-10-12-sparklyr-flint-0.2.0-released/index.md
@@ -17,6 +17,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2020-10-19-torch-image-classification/index.Rmd
+++ b/content/blog/ai/2020-10-19-torch-image-classification/index.Rmd
@@ -13,6 +13,7 @@ categories:
 bibliography: bibliography.bib
 preview: images/image_classif_birds.png
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-10-19-torch-image-classification/index.md
+++ b/content/blog/ai/2020-10-19-torch-image-classification/index.md
@@ -16,6 +16,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-11-03-torch-tabular/index.Rmd
+++ b/content/blog/ai/2020-11-03-torch-tabular/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpeg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-11-03-torch-tabular/index.md
+++ b/content/blog/ai/2020-11-03-torch-tabular/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpeg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-11-30-torch-brain-segmentation/index.Rmd
+++ b/content/blog/ai/2020-11-30-torch-brain-segmentation/index.Rmd
@@ -13,6 +13,7 @@ categories:
 bibliography: bibliography.bib
 preview: images/scans.png
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-11-30-torch-brain-segmentation/index.md
+++ b/content/blog/ai/2020-11-30-torch-brain-segmentation/index.md
@@ -16,6 +16,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-12-14-sparklyr-1.5.0-released/index.Rmd
+++ b/content/blog/ai/2020-12-14-sparklyr-1.5.0-released/index.Rmd
@@ -14,6 +14,7 @@ categories:
   - MLOps and Admin
 preview: images/sparklyr-1.5.jpg
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2020-12-14-sparklyr-1.5.0-released/index.md
+++ b/content/blog/ai/2020-12-14-sparklyr-1.5.0-released/index.md
@@ -19,6 +19,7 @@ image-alt: A hollywood star with the text 'sparklyr 1.5'
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2020-12-15-torch-0.2.0-released/index.Rmd
+++ b/content/blog/ai/2020-12-15-torch-0.2.0-released/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Machine Learning
 preview: images/torch.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-12-15-torch-0.2.0-released/index.md
+++ b/content/blog/ai/2020-12-15-torch-0.2.0-released/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-12-17-torch-convlstm/index.Rmd
+++ b/content/blog/ai/2020-12-17-torch-convlstm/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpeg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2020-12-17-torch-convlstm/index.md
+++ b/content/blog/ai/2020-12-17-torch-convlstm/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpeg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-02-02-enso-prediction/index.Rmd
+++ b/content/blog/ai/2021-02-02-enso-prediction/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Machine Learning
 preview: images/pic.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-02-02-enso-prediction/index.md
+++ b/content/blog/ai/2021-02-02-enso-prediction/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-02-04-simple-audio-classification-with-torch/index.Rmd
+++ b/content/blog/ai/2021-02-04-simple-audio-classification-with-torch/index.Rmd
@@ -14,6 +14,7 @@ preview: images/preview.jpg
 editor_options:
   chunk_output_type: console
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-02-04-simple-audio-classification-with-torch/index.md
+++ b/content/blog/ai/2021-02-04-simple-audio-classification-with-torch/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-02-11-tabnet/index.Rmd
+++ b/content/blog/ai/2021-02-11-tabnet/index.Rmd
@@ -13,7 +13,7 @@ categories:
   - Machine Learning
 preview: images/d.jpg
 format: hugo-md
-software: ["tidymodels", "tabnet"]
+software: ["tidymodels", "tabnet", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-02-11-tabnet/index.Rmd
+++ b/content/blog/ai/2021-02-11-tabnet/index.Rmd
@@ -13,7 +13,7 @@ categories:
   - Machine Learning
 preview: images/d.jpg
 format: hugo-md
-software: ["tidymodels"]
+software: ["tidymodels", "tabnet"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-02-11-tabnet/index.md
+++ b/content/blog/ai/2021-02-11-tabnet/index.md
@@ -16,7 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
-software: ["tidymodels", "tabnet"]
+software: ["tidymodels", "tabnet", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-02-11-tabnet/index.md
+++ b/content/blog/ai/2021-02-11-tabnet/index.md
@@ -16,7 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
-software: ["tidymodels"]
+software: ["tidymodels", "tabnet"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-02-17-survey/index.Rmd
+++ b/content/blog/ai/2021-02-17-survey/index.Rmd
@@ -18,6 +18,7 @@ ported_categories:
 tags:
   - AI
   - Meta
+software: ["sparklyr"]
 ---
 
 ```{r setup, include=FALSE}

--- a/content/blog/ai/2021-02-17-survey/index.Rmd
+++ b/content/blog/ai/2021-02-17-survey/index.Rmd
@@ -18,7 +18,7 @@ ported_categories:
 tags:
   - AI
   - Meta
-software: ["sparklyr"]
+software: ["sparklyr", "torch"]
 ---
 
 ```{r setup, include=FALSE}

--- a/content/blog/ai/2021-02-17-survey/index.md
+++ b/content/blog/ai/2021-02-17-survey/index.md
@@ -22,6 +22,7 @@ ported_categories:
 tags:
   - AI
   - Meta
+software: ["sparklyr"]
 ---
 
 

--- a/content/blog/ai/2021-02-17-survey/index.md
+++ b/content/blog/ai/2021-02-17-survey/index.md
@@ -22,7 +22,7 @@ ported_categories:
 tags:
   - AI
   - Meta
-software: ["sparklyr"]
+software: ["sparklyr", "torch"]
 ---
 
 

--- a/content/blog/ai/2021-03-10-forecasting-time-series-with-torch_1/index.Rmd
+++ b/content/blog/ai/2021-03-10-forecasting-time-series-with-torch_1/index.Rmd
@@ -14,6 +14,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-03-10-forecasting-time-series-with-torch_1/index.md
+++ b/content/blog/ai/2021-03-10-forecasting-time-series-with-torch_1/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-03-11-forecasting-time-series-with-torch_2/index.Rmd
+++ b/content/blog/ai/2021-03-11-forecasting-time-series-with-torch_2/index.Rmd
@@ -14,6 +14,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-03-11-forecasting-time-series-with-torch_2/index.md
+++ b/content/blog/ai/2021-03-11-forecasting-time-series-with-torch_2/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-03-16-forecasting-time-series-with-torch_3/index.Rmd
+++ b/content/blog/ai/2021-03-16-forecasting-time-series-with-torch_3/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-03-16-forecasting-time-series-with-torch_3/index.md
+++ b/content/blog/ai/2021-03-16-forecasting-time-series-with-torch_3/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-03-19-forecasting-time-series-with-torch_4/index.Rmd
+++ b/content/blog/ai/2021-03-19-forecasting-time-series-with-torch_4/index.Rmd
@@ -13,6 +13,7 @@ categories:
 bibliography: bibliography.bib
 preview: images/preview.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-03-19-forecasting-time-series-with-torch_4/index.md
+++ b/content/blog/ai/2021-03-19-forecasting-time-series-with-torch_4/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-03-25-sparklyr-1.6.0-released/index.Rmd
+++ b/content/blog/ai/2021-03-25-sparklyr-1.6.0-released/index.Rmd
@@ -15,6 +15,7 @@ categories:
   - MLOps and Admin
 preview: images/sparklyr-1.6.jpg
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2021-03-25-sparklyr-1.6.0-released/index.md
+++ b/content/blog/ai/2021-03-25-sparklyr-1.6.0-released/index.md
@@ -19,6 +19,7 @@ image-alt: A lightbulb emitting many sparks
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2021-04-22-torch-for-optimization/index.Rmd
+++ b/content/blog/ai/2021-04-22-torch-for-optimization/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-04-22-torch-for-optimization/index.md
+++ b/content/blog/ai/2021-04-22-torch-for-optimization/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-06-17-luz/index.Rmd
+++ b/content/blog/ai/2021-06-17-luz/index.Rmd
@@ -15,6 +15,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpg
 format: hugo-md
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-06-17-luz/index.Rmd
+++ b/content/blog/ai/2021-06-17-luz/index.Rmd
@@ -15,7 +15,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpg
 format: hugo-md
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-06-17-luz/index.md
+++ b/content/blog/ai/2021-06-17-luz/index.md
@@ -16,7 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-06-17-luz/index.md
+++ b/content/blog/ai/2021-06-17-luz/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-07-06-sparklyr-1.7.0-released/index.Rmd
+++ b/content/blog/ai/2021-07-06-sparklyr-1.7.0-released/index.Rmd
@@ -15,6 +15,7 @@ categories:
   - MLOps and Admin
 preview: images/sparklyr-1.7.png
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2021-07-06-sparklyr-1.7.0-released/index.md
+++ b/content/blog/ai/2021-07-06-sparklyr-1.7.0-released/index.md
@@ -18,6 +18,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2021-07-07-sparklyr-sedona/index.Rmd
+++ b/content/blog/ai/2021-07-07-sparklyr-sedona/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - MLOps and Admin
 preview: images/nasa-Q1p7bh3SHj8-unsplash.jpg
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2021-07-07-sparklyr-sedona/index.md
+++ b/content/blog/ai/2021-07-07-sparklyr-sedona/index.md
@@ -17,6 +17,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - R

--- a/content/blog/ai/2021-08-10-jit-trace-module/index.Rmd
+++ b/content/blog/ai/2021-08-10-jit-trace-module/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-08-10-jit-trace-module/index.md
+++ b/content/blog/ai/2021-08-10-jit-trace-module/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-10-29-segmentation-torch-android/index.Rmd
+++ b/content/blog/ai/2021-10-29-segmentation-torch-android/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Machine Learning
 preview: images/segmentation_android.png
 format: hugo-md
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-10-29-segmentation-torch-android/index.Rmd
+++ b/content/blog/ai/2021-10-29-segmentation-torch-android/index.Rmd
@@ -13,7 +13,7 @@ categories:
   - Machine Learning
 preview: images/segmentation_android.png
 format: hugo-md
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-10-29-segmentation-torch-android/index.md
+++ b/content/blog/ai/2021-10-29-segmentation-torch-android/index.md
@@ -16,7 +16,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2021-10-29-segmentation-torch-android/index.md
+++ b/content/blog/ai/2021-10-29-segmentation-torch-android/index.md
@@ -16,6 +16,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-04-27-torch-outside-the-box/index.Rmd
+++ b/content/blog/ai/2022-04-27-torch-outside-the-box/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-04-27-torch-outside-the-box/index.md
+++ b/content/blog/ai/2022-04-27-torch-outside-the-box/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-05-18-torchopt/index.Rmd
+++ b/content/blog/ai/2022-05-18-torchopt/index.Rmd
@@ -13,6 +13,7 @@ categories:
 bibliography: bibliography.bib
 preview: images/petals.png
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-05-18-torchopt/index.md
+++ b/content/blog/ai/2022-05-18-torchopt/index.md
@@ -16,6 +16,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-08-24-luz-0-3/index.Rmd
+++ b/content/blog/ai/2022-08-24-luz-0-3/index.Rmd
@@ -16,7 +16,7 @@ editor_options:
 preview: images/bulbs.jpeg
 slug: luz-0-3-0
 format: hugo-md
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-08-24-luz-0-3/index.Rmd
+++ b/content/blog/ai/2022-08-24-luz-0-3/index.Rmd
@@ -16,6 +16,7 @@ editor_options:
 preview: images/bulbs.jpeg
 slug: luz-0-3-0
 format: hugo-md
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-08-24-luz-0-3/index.md
+++ b/content/blog/ai/2022-08-24-luz-0-3/index.md
@@ -16,7 +16,7 @@ image: thumbnail.jpeg
 ported_from: ai
 source: ai
 port_status: in-progress
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-08-24-luz-0-3/index.md
+++ b/content/blog/ai/2022-08-24-luz-0-3/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpeg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-06-audio-classification-torch/index.Rmd
+++ b/content/blog/ai/2022-10-06-audio-classification-torch/index.Rmd
@@ -15,6 +15,7 @@ categories:
 bibliography: bibliography.bib
 preview: images/squirrel.jpg
 format: hugo-md
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-06-audio-classification-torch/index.Rmd
+++ b/content/blog/ai/2022-10-06-audio-classification-torch/index.Rmd
@@ -15,7 +15,7 @@ categories:
 bibliography: bibliography.bib
 preview: images/squirrel.jpg
 format: hugo-md
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-06-audio-classification-torch/index.md
+++ b/content/blog/ai/2022-10-06-audio-classification-torch/index.md
@@ -16,7 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-06-audio-classification-torch/index.md
+++ b/content/blog/ai/2022-10-06-audio-classification-torch/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-13-torch-linalg/index.Rmd
+++ b/content/blog/ai/2022-10-13-torch-linalg/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Best Practices
 preview: images/squirrel.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-13-torch-linalg/index.md
+++ b/content/blog/ai/2022-10-13-torch-linalg/index.md
@@ -17,6 +17,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-20-dft/index.Rmd
+++ b/content/blog/ai/2022-10-20-dft/index.Rmd
@@ -18,6 +18,7 @@ categories:
   - Best Practices
 preview: images/squirrel.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-20-dft/index.md
+++ b/content/blog/ai/2022-10-20-dft/index.md
@@ -17,6 +17,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-25-torch-0-9/index.Rmd
+++ b/content/blog/ai/2022-10-25-torch-0-9/index.Rmd
@@ -15,6 +15,7 @@ editor_options:
 preview: images/banner.jpeg
 slug: torch-0-9-0
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-25-torch-0-9/index.md
+++ b/content/blog/ai/2022-10-25-torch-0-9/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpeg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-27-wavelets/index.Rmd
+++ b/content/blog/ai/2022-10-27-wavelets/index.Rmd
@@ -14,6 +14,7 @@ categories:
 bibliography: bibliography.bib
 preview: images/squirrel.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2022-10-27-wavelets/index.md
+++ b/content/blog/ai/2022-10-27-wavelets/index.md
@@ -17,6 +17,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-01-19-torchwavelets/index.Rmd
+++ b/content/blog/ai/2023-01-19-torchwavelets/index.Rmd
@@ -13,6 +13,7 @@ categories:
 bibliography: bibliography.bib
 preview: images/preview.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-01-19-torchwavelets/index.md
+++ b/content/blog/ai/2023-01-19-torchwavelets/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-03-27-group-equivariant-cnn-2/index.Rmd
+++ b/content/blog/ai/2023-03-27-group-equivariant-cnn-2/index.Rmd
@@ -12,7 +12,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpg
 format: hugo-md
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-03-27-group-equivariant-cnn-2/index.Rmd
+++ b/content/blog/ai/2023-03-27-group-equivariant-cnn-2/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/preview.jpg
 format: hugo-md
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-03-27-group-equivariant-cnn-2/index.md
+++ b/content/blog/ai/2023-03-27-group-equivariant-cnn-2/index.md
@@ -16,7 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-03-27-group-equivariant-cnn-2/index.md
+++ b/content/blog/ai/2023-03-27-group-equivariant-cnn-2/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-04-05-deep-learning-scientific-computing-R-torch/index.Rmd
+++ b/content/blog/ai/2023-04-05-deep-learning-scientific-computing-R-torch/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Best Practices
 preview: images/book.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-04-05-deep-learning-scientific-computing-R-torch/index.md
+++ b/content/blog/ai/2023-04-05-deep-learning-scientific-computing-R-torch/index.md
@@ -17,6 +17,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-04-13-denoising-diffusion/index.Rmd
+++ b/content/blog/ai/2023-04-13-denoising-diffusion/index.Rmd
@@ -19,6 +19,7 @@ editor_options:
   markdown:
     wrap: 72
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-04-13-denoising-diffusion/index.md
+++ b/content/blog/ai/2023-04-13-denoising-diffusion/index.md
@@ -20,6 +20,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-04-14-torch-0-10/index.Rmd
+++ b/content/blog/ai/2023-04-14-torch-0-10/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/torch.png
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-04-14-torch-0-10/index.md
+++ b/content/blog/ai/2023-04-14-torch-0-10/index.md
@@ -16,6 +16,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-04-17-luz-0-4/index.Rmd
+++ b/content/blog/ai/2023-04-17-luz-0-4/index.Rmd
@@ -12,7 +12,7 @@ categories:
   - Machine Learning
 preview: images/luz.jpg
 format: hugo-md
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-04-17-luz-0-4/index.Rmd
+++ b/content/blog/ai/2023-04-17-luz-0-4/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/luz.jpg
 format: hugo-md
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-04-17-luz-0-4/index.md
+++ b/content/blog/ai/2023-04-17-luz-0-4/index.md
@@ -16,7 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
-software: ["luz"]
+software: ["luz", "torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-04-17-luz-0-4/index.md
+++ b/content/blog/ai/2023-04-17-luz-0-4/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["luz"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-06-07-torch-0-11/index.Rmd
+++ b/content/blog/ai/2023-06-07-torch-0-11/index.Rmd
@@ -14,6 +14,7 @@ categories:
   - Machine Learning
 preview: images/ian-schneider-PAykYb-8Er8-unsplash.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-06-07-torch-0-11/index.md
+++ b/content/blog/ai/2023-06-07-torch-0-11/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-06-15-safetensors/index.Rmd
+++ b/content/blog/ai/2023-06-15-safetensors/index.Rmd
@@ -12,6 +12,7 @@ categories:
   - Machine Learning
 preview: images/nick-fewings-4pZu15OeTXA-unsplash.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Packages/Releases

--- a/content/blog/ai/2023-06-15-safetensors/index.md
+++ b/content/blog/ai/2023-06-15-safetensors/index.md
@@ -16,6 +16,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Packages/Releases

--- a/content/blog/ai/2023-06-20-gpt2-torch/index.Rmd
+++ b/content/blog/ai/2023-06-20-gpt2-torch/index.Rmd
@@ -14,6 +14,7 @@ categories:
 bibliography: references.bib
 preview: images/preview.jpg
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-06-20-gpt2-torch/index.md
+++ b/content/blog/ai/2023-06-20-gpt2-torch/index.md
@@ -17,6 +17,7 @@ image: thumbnail.jpg
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-06-22-understanding-lora/index.Rmd
+++ b/content/blog/ai/2023-06-22-understanding-lora/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Best Practices
 preview: images/lora.png
 format: hugo-md
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2023-06-22-understanding-lora/index.md
+++ b/content/blog/ai/2023-06-22-understanding-lora/index.md
@@ -17,6 +17,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Torch

--- a/content/blog/ai/2024-04-04-chat-with-llms-using-chattr/index.Rmd
+++ b/content/blog/ai/2024-04-04-chat-with-llms-using-chattr/index.Rmd
@@ -12,7 +12,7 @@ categories:
   - Artificial Intelligence
 preview: images/chattr.png
 format: hugo-md
-software: ["rstudio"]
+software: ["rstudio", "chattr"]
 languages: ["R"]
 ported_categories:
   - Generenative Models

--- a/content/blog/ai/2024-04-04-chat-with-llms-using-chattr/index.md
+++ b/content/blog/ai/2024-04-04-chat-with-llms-using-chattr/index.md
@@ -16,7 +16,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
-software: ["rstudio"]
+software: ["rstudio", "chattr"]
 languages: ["R"]
 ported_categories:
   - Generenative Models

--- a/content/blog/ai/2024-04-22-sparklyr-updates/index.Rmd
+++ b/content/blog/ai/2024-04-22-sparklyr-updates/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Data Wrangling
 preview: images/sparklyr.png
 format: hugo-md
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages/Releases

--- a/content/blog/ai/2024-04-22-sparklyr-updates/index.md
+++ b/content/blog/ai/2024-04-22-sparklyr-updates/index.md
@@ -17,6 +17,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages/Releases

--- a/content/blog/ai/2024-10-30-mall/index.Rmd
+++ b/content/blog/ai/2024-10-30-mall/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Machine Learning
 preview: images/article.png
 format: hugo-md
+software: ["mall"]
 languages: ["R", "Python"]
 ported_categories:
   - Python

--- a/content/blog/ai/2024-10-30-mall/index.md
+++ b/content/blog/ai/2024-10-30-mall/index.md
@@ -17,6 +17,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["mall"]
 languages: ["R", "Python"]
 ported_categories:
   - Python

--- a/content/blog/ai/2025-08-19-mall-0-2/index.Rmd
+++ b/content/blog/ai/2025-08-19-mall-0-2/index.Rmd
@@ -13,6 +13,7 @@ categories:
   - Machine Learning
 preview: images/article.png
 format: hugo-md
+software: ["mall"]
 languages: ["R", "Python"]
 ported_categories:
   - Python

--- a/content/blog/ai/2025-08-19-mall-0-2/index.md
+++ b/content/blog/ai/2025-08-19-mall-0-2/index.md
@@ -17,6 +17,7 @@ image: thumbnail.png
 ported_from: ai
 source: ai
 port_status: in-progress
+software: ["mall"]
 languages: ["R", "Python"]
 ported_categories:
   - Python

--- a/content/blog/rstudio/2016-09-27-sparklyr-r-interface-for-apache-spark/index.md
+++ b/content/blog/rstudio/2016-09-27-sparklyr-r-interface-for-apache-spark/index.md
@@ -19,6 +19,7 @@ tags:
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - News

--- a/content/blog/rstudio/2017-01-24-sparklyr-0-5/index.md
+++ b/content/blog/rstudio/2017-01-24-sparklyr-0-5/index.md
@@ -21,6 +21,7 @@ blogcategories:
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages

--- a/content/blog/rstudio/2017-07-31-sparklyr-0-6/index.md
+++ b/content/blog/rstudio/2017-07-31-sparklyr-0-6/index.md
@@ -21,6 +21,7 @@ blogcategories:
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages

--- a/content/blog/rstudio/2018-01-29-sparklyr-0-7/index.md
+++ b/content/blog/rstudio/2018-01-29-sparklyr-0-7/index.md
@@ -22,6 +22,7 @@ blogcategories:
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages

--- a/content/blog/rstudio/2018-05-14-sparklyr-0-8/index.md
+++ b/content/blog/rstudio/2018-05-14-sparklyr-0-8/index.md
@@ -19,6 +19,7 @@ blogcategories:
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages

--- a/content/blog/rstudio/2018-10-01-sparklyr-0-9/index.md
+++ b/content/blog/rstudio/2018-10-01-sparklyr-0-9/index.md
@@ -22,6 +22,7 @@ blogcategories:
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages

--- a/content/blog/rstudio/2019-03-06-sparklyr-1-0/index.md
+++ b/content/blog/rstudio/2019-03-06-sparklyr-1-0/index.md
@@ -22,6 +22,7 @@ blogcategories:
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages

--- a/content/blog/rstudio/2020-01-29-sparklyr-1-1-foundations-books-lakes-and-barriers/index.md
+++ b/content/blog/rstudio/2020-01-29-sparklyr-1-1-foundations-books-lakes-and-barriers/index.md
@@ -20,6 +20,7 @@ blogcategories:
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages

--- a/content/blog/rstudio/2020-05-04-sparklyr-1-2-foreach-spark-3-0-and-databricks-connect/index.md
+++ b/content/blog/rstudio/2020-05-04-sparklyr-1-2-foreach-spark-3-0-and-databricks-connect/index.md
@@ -22,6 +22,7 @@ image: thumbnail.jpg
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages

--- a/content/blog/rstudio/2020-07-16-sparklyr-1-3-higher-order-functions-avro-and-custom-serializers/index.md
+++ b/content/blog/rstudio/2020-07-16-sparklyr-1-3-higher-order-functions-avro-and-custom-serializers/index.md
@@ -22,6 +22,7 @@ image-alt: SparklyR
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["sparklyr"]
 languages: ["R"]
 ported_categories:
   - Packages

--- a/content/blog/rstudio/2020-09-29-introducing-torch-for-R/index.md
+++ b/content/blog/rstudio/2020-09-29-introducing-torch-for-R/index.md
@@ -28,6 +28,7 @@ blogcategories:
 ported_from: rstudio
 source: rstudio
 port_status: in-progress
+software: ["torch"]
 languages: ["R"]
 ported_categories:
   - Packages

--- a/content/blog/tidyverse/2024/tidymodels-2024-survey/index.Rmd
+++ b/content/blog/tidyverse/2024/tidymodels-2024-survey/index.Rmd
@@ -18,7 +18,7 @@ tags:
 image: thumbnail-wd.jpg
 ported_from: tidyverse
 port_status: raw
-software: ["tidyverse", "tidymodels"]
+software: ["tidyverse", "tidymodels", "chattr"]
 languages: ["R"]
 ported_categories:
   - other

--- a/content/blog/tidyverse/2024/tidymodels-2024-survey/index.md
+++ b/content/blog/tidyverse/2024/tidymodels-2024-survey/index.md
@@ -18,7 +18,7 @@ image: thumbnail-wd.jpg
 ported_from: tidyverse
 source: tidyverse
 port_status: in-progress
-software: ["tidyverse", "tidymodels"]
+software: ["tidyverse", "tidymodels", "chattr"]
 languages: ["R"]
 ported_categories:
   - other

--- a/content/blog/torch-ecosystem-updates-2026/index.md
+++ b/content/blog/torch-ecosystem-updates-2026/index.md
@@ -12,6 +12,7 @@ topics:
   - Machine Learning
 software:
   - torch
+  - luz
 languages:
   - R
 ---


### PR DESCRIPTION
## Summary

Follow-up pass on the blog corpus to back-tag `software` entries that became available after the original bulk-tagging effort:

**Commit 1 — `sparklyr`, `luz`, `chattr`, `mall`, `tabnet`** (from #216):
- **sparklyr** — 22 posts (release announcements 0.5–1.7, sparklyr.flint, sparklyr.sedona, parallelized-sampling deep dive, sparkly-verse update, mlverse survey)
- **luz** — 7 posts (introduction, 0.3 / 0.4 releases, segmentation-on-Android, audio classification, group-equivariant CNN, torch ecosystem update)
- **chattr** — 2 posts (chattr intro, tidymodels-2024 survey "Improve chattr" section)
- **mall** — 2 posts (mall intro, mall 0.2)
- **tabnet** — 1 post (torch + tidymodels + high-energy physics)

**Commit 2 — `torch`** (already in `content/software/` but untagged from the earlier pass):
- 40 posts tagged across torch tutorials, releases (0.2 / 0.9 / 0.10 / 0.11), the time-series-with-torch series, brain/audio/image segmentation, torchopt, torchwavelets, safetensors, the torch book, etc.
- Skipped posts that only use Python's torch via reticulate: `2023-05-25-llama-tensorflow-keras`, `2023-05-09-group-equivariant-cnn-3` (escnn), `2024-05-21-keras3` (torch mentioned as a Keras 3 backend option).

Each tag was added to both the rendered `index.md` and the source `index.Rmd` where present, so a re-render won't lose the change.

Mention-only candidates were skipped (e.g., `rstudio-ai-blog` intro, `teach-tidyverse-2021`, `bundle-0-1-0`, `deep-learning-scientific-computing-R-torch` book post for sparklyr/luz; newsletters, parsnip/usethis/tabpfn/brulee/bundle release posts for torch).

## Test plan

- [x] `python3 scripts/validate-blog-posts.py` on all changed `.md` files — no errors (only pre-existing warnings: image-alt, missing people pages)
- [x] `hugo --renderToMemory` builds cleanly
- [ ] Spot-check `/software/sparklyr/`, `/software/luz/`, `/software/chattr/`, `/software/mall/`, `/software/tabnet/`, `/software/torch/` listing pages