### PR TITLE
Add resources on  video for Building Accessible, On-Brand Documents with Quarto

### DIFF
--- a/content/resources/videos/2026-05-13_building-accessible-on-brand-documents-with-quarto/_index.md
+++ b/content/resources/videos/2026-05-13_building-accessible-on-brand-documents-with-quarto/_index.md
@@ -62,3 +62,7 @@ external:  # updated automatically, do not edit
   view_count: 177
 ---
 
+## Resources
+
+{{< button url="https://cwickham.github.io/accessible-branded-documents/" text="Slides" icon="tabler--presentation" >}}
+{{< button url="https://github.com/cwickham/accessible-branded-documents" text="Demo repo" icon="simple-icons--github" >}}

--- a/layouts/resources/term.html
+++ b/layouts/resources/term.html
@@ -324,6 +324,11 @@
         {{- /* Video transcript or regular content */ -}}
         {{ if eq .Params.resource_type "video" }}
         {{ $transcriptResource := .Resources.Get "transcription.txt" }}
+        {{ if and $transcriptResource .Content }}
+        <div class="w-full prose text-[1.075rem] prose-quoteless post-content max-w-none lg:max-w-[65ch] mb-8">
+          {{ .Content | safeHTML }}
+        </div>
+        {{ end }}
         {{ if $transcriptResource }}
         <div data-pagefind-body class="w-full prose text-[1.075rem] prose-quoteless post-content max-w-none lg:max-w-[65ch]">
           {{ partial "heading.html" (dict "level" 2 "text" "Transcript") }}

--- a/safelist.txt
+++ b/safelist.txt
@@ -56,6 +56,7 @@ icon-[simple-icons--mastodon]
 icon-[simple-icons--orcid]
 icon-[simple-icons--youtube]
 icon-[tabler--external-link]
+icon-[tabler--presentation]
 object-contain
 object-cover
 bg-blue-300


### PR DESCRIPTION
## Summary
- Adds a `## Resources` section to the *Building Accessible, On-Brand Documents with Quarto* video page with Slides + Demo repo buttons.
- Fixes a layout bug where `.Content` was dropped on video resource pages whenever a transcript was present — body content now renders above the transcript.
- Safelists `icon-[tabler--presentation]` so the new Slides icon survives the Tailwind build.

## Test plan
- [ ] `/resources/videos/2026-05-13_building-accessible-on-brand-documents-with-quarto/` shows two buttons (Slides, Demo repo) with correct icons above the transcript.
- [ ] Existing video pages (no body content) are unchanged.
- [ ] Non-video resource pages are unchanged.