### PR TITLE
Add .code-with-filename CSS styles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -371,6 +371,10 @@ html {
   border-radius: 0;
 }
 
+.code-with-filename .highlight .chroma .lntable {
+  margin: 0;
+}
+
 .prose .code-with-filename div.highlight button {
   top: 0.5rem !important;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -378,7 +378,8 @@ html {
   border-radius: 0;
 }
 
-.code-with-filename div.highlight button {
+.code-with-filename div.highlight button,
+.prose .code-with-filename div.highlight button {
   top: 0.5rem !important;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -349,6 +349,32 @@ html {
   border-radius: 0.75rem;
 }
 
+.code-with-filename {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--color-blue-200);
+}
+
+.code-with-filename .code-with-filename-label {
+  background-color: var(--color-blue-200);
+  padding: 0.4rem 1.1428571em;
+  border-bottom: 1px solid var(--color-blue-200);
+}
+
+.prose .code-with-filename div.highlight {
+  border-radius: 0 !important;
+}
+
+.code-with-filename .highlight pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  border-radius: 0;
+}
+
+.prose .code-with-filename div.highlight button {
+  top: 0.5rem !important;
+}
+
 /* Copy button icons - light mode */
 .highlight button .icon-tabler.icon-tabler-copy {
   stroke: var(--color-gray-600);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -365,7 +365,8 @@ html {
   border-radius: 0 !important;
 }
 
-.code-with-filename .highlight pre {
+.code-with-filename .highlight pre,
+.code-with-filename > pre {
   margin-top: 0;
   margin-bottom: 0;
   border-radius: 0;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -361,7 +361,7 @@ html {
   border-bottom: 1px solid var(--color-blue-200);
 }
 
-.prose .code-with-filename div.highlight {
+.code-with-filename div.highlight {
   border-radius: 0 !important;
 }
 
@@ -376,7 +376,7 @@ html {
   margin: 0;
 }
 
-.prose .code-with-filename div.highlight button {
+.code-with-filename div.highlight button {
   top: 0.5rem !important;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -358,7 +358,6 @@ html {
 .code-with-filename .code-with-filename-label {
   background-color: var(--color-blue-200);
   padding: 0.4rem 1.1428571em;
-  border-bottom: 1px solid var(--color-blue-200);
 }
 
 .code-with-filename div.highlight,

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -361,7 +361,8 @@ html {
   border-bottom: 1px solid var(--color-blue-200);
 }
 
-.code-with-filename div.highlight {
+.code-with-filename div.highlight,
+.prose .code-with-filename div.highlight {
   border-radius: 0 !important;
 }
 
@@ -374,6 +375,7 @@ html {
 
 .code-with-filename .highlight .chroma .lntable {
   margin: 0;
+  border-radius: 0;
 }
 
 .code-with-filename div.highlight button {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -352,7 +352,6 @@ html {
 .code-with-filename {
   border-radius: 0.75rem;
   overflow: hidden;
-  border: 1px solid var(--color-blue-200);
 }
 
 .code-with-filename .code-with-filename-label {

--- a/content/test-filename/index.md
+++ b/content/test-filename/index.md
@@ -1,6 +1,7 @@
 ---
 title: Test Filename on Code Blocks
 layout: single
+code-line-numbers: true
 ---
 
 

--- a/content/test-filename/index.md
+++ b/content/test-filename/index.md
@@ -56,3 +56,4 @@ print("hello world")
 project:
   type: website
 ```
+

--- a/content/test-filename/index.md
+++ b/content/test-filename/index.md
@@ -7,6 +7,7 @@ code-line-numbers: true
 
 ## Code block with filename
 
+
 ``` python { filename="app.py" }
 from shiny.express import input, ui
 import shinyswatch
@@ -22,6 +23,7 @@ print("hello world")
 
 ## Another filename
 
+
 ``` yaml { filename="_quarto.yml" }
 project:
   type: website
@@ -32,12 +34,14 @@ format:
 
 ## Plain text with filename
 
+
 ``` { filename="Makefile" }
 build:
     echo "building..."
 ```
 
 ## Filename with code-line-numbers
+
 
 ``` python { filename="app.py" }
 from shiny.express import input, ui
@@ -47,14 +51,41 @@ ui.input_slider("num", "Number:", min=10, max=100, value=30)
 
 ## Filename with custom class
 
+
 ``` python { filename="example.py" }
 print("hello world")
 ```
 
 ## Filename with shortcodes=false
 
+
 ``` yaml { filename="_quarto.yml" }
 project:
   type: website
 ```
 
+## Filename with path
+
+
+``` python { filename="src/app.py" }
+from shiny.express import input, ui
+
+ui.input_slider("num", "Number:", min=10, max=100, value=30)
+```
+
+## Long filename
+
+
+``` python { filename="this-is-a-very-long-descriptive-filename-that-might-overflow.py" }
+print("testing label overflow")
+```
+
+## R code with filename
+
+
+``` r { filename="analysis.R" }
+library(ggplot2)
+
+ggplot(mtcars, aes(x = wt, y = mpg)) +
+  geom_point()
+```

--- a/content/test-filename/index.qmd
+++ b/content/test-filename/index.qmd
@@ -55,3 +55,26 @@ print("hello world")
 project:
   type: website
 ```
+
+## Filename with path
+
+```{.python filename="src/app.py"}
+from shiny.express import input, ui
+
+ui.input_slider("num", "Number:", min=10, max=100, value=30)
+```
+
+## Long filename
+
+```{.python filename="this-is-a-very-long-descriptive-filename-that-might-overflow.py"}
+print("testing label overflow")
+```
+
+## R code with filename
+
+```{.r filename="analysis.R"}
+library(ggplot2)
+
+ggplot(mtcars, aes(x = wt, y = mpg)) +
+  geom_point()
+```

--- a/content/test-filename/index.qmd
+++ b/content/test-filename/index.qmd
@@ -1,6 +1,7 @@
 ---
 title: Test Filename on Code Blocks
 layout: single
+code-line-numbers: true
 ---
 
 ## Code block with filename


### PR DESCRIPTION
## Summary

Extracts the CSS changes from #244 as a standalone PR so they can merge independently (thanks @cpsievert!)

Adds styles for Quarto's `code-with-filename` feature — code blocks that display a filename label above the code:

- Rounded border with blue accent
- Filename label with blue background
- Removes inner border-radius so the code block fits flush inside the container
- Adjusts copy-button position for the nested layout

Line numbers are enabled on the test page via `code-line-numbers: true` in frontmatter, keeping to the convention of specifying this at the page level rather than per block.

## Test plan

- [x] Code blocks with `filename=` attribute render with a labeled header and bordered container
- [x] Copy button is correctly positioned inside `code-with-filename` blocks