### PR TITLE
Recreate preview-links comment on each deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -174,5 +174,6 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: content-preview-links
+          recreate: true
           number: ${{ github.event.pull_request.number || github.event.issue.number }}
           path: /tmp/preview-comment.md


### PR DESCRIPTION
## Summary
- Adds `recreate: true` to the sticky preview-links comment in `deploy-preview.yml`, matching what `comment-blog-validation.yml` already does.
- Each new deploy now deletes the old "Preview links" comment and posts a fresh one, so the comment lands at the bottom of the PR after the latest commit — clearer signal that the deploy ran against that commit.

## Test plan
- [x] Push a follow-up commit to a PR using this branch's workflow and confirm the preview-links comment is deleted and re-posted (rather than edited in place).