### PR TITLE
Add image lightbox opt-in and PDF lightbox support for cheatsheets

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -386,7 +386,7 @@ html {
   top: 0.5rem !important;
 }
 
-/* Copy button icons - light mode */
+/* Copy button icons */
 .highlight button .icon-tabler.icon-tabler-copy {
   stroke: var(--color-gray-400);
   transition: stroke 0.2s ease;
@@ -400,7 +400,7 @@ html {
   stroke: var(--color-green-600);
 }
 
-/* Checkmark draw-in animation */
+/* Checkmark draw-in animation - stroke length approximation for smooth animation */
 .highlight .icon-tabler.icon-tabler-check path {
   stroke-dasharray: 50;
   stroke-dashoffset: 50;
@@ -845,19 +845,29 @@ mark[data-pagefind-highlight],
   transition: opacity 0.2s ease-out;
 }
 
-#image-lightbox img {
-  border-radius: 0.5rem;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  animation: lightbox-zoom 0.2s ease-out;
-}
-
+#image-lightbox img,
 #image-lightbox iframe {
   border-radius: 0.5rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+#image-lightbox img {
   animation: lightbox-zoom 0.2s ease-out;
-  width: 90vw;
-  height: 90vh;
+  touch-action: pan-x pan-y pinch-zoom;
+}
+
+#image-lightbox iframe {
+  width: 95vw;
+  height: 95vh;
   background: white;
+  animation: lightbox-fade 0.2s ease-out;
+}
+
+@media (min-width: 768px) {
+  #image-lightbox iframe {
+    width: 90vw;
+    height: 90vh;
+  }
 }
 
 @keyframes lightbox-zoom {
@@ -869,6 +879,28 @@ mark[data-pagefind-highlight],
     opacity: 1;
     transform: scale(1);
   }
+}
+
+@keyframes lightbox-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Screen reader only class */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }
 
 /* Tabsets */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -834,40 +834,24 @@ mark[data-pagefind-highlight],
 
 /* Image Lightbox */
 .prose img[role="button"] {
-  transition: opacity 0.2s ease;
-}
-
-.prose img[role="button"]:hover {
-  opacity: 0.9;
+  @apply transition-opacity duration-200 hover:opacity-90;
 }
 
 #image-lightbox {
-  transition: opacity 0.2s ease-out;
+  @apply transition-opacity duration-200;
 }
 
 #image-lightbox img,
 #image-lightbox iframe {
-  border-radius: 0.5rem;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  @apply rounded-lg shadow-lg;
 }
 
 #image-lightbox img {
   animation: lightbox-zoom 0.2s ease-out;
-  touch-action: pan-x pan-y pinch-zoom;
 }
 
 #image-lightbox iframe {
-  width: 95vw;
-  height: 95vh;
-  background: white;
   animation: lightbox-fade 0.2s ease-out;
-}
-
-@media (min-width: 768px) {
-  #image-lightbox iframe {
-    width: 90vw;
-    height: 90vh;
-  }
 }
 
 @keyframes lightbox-zoom {
@@ -888,19 +872,6 @@ mark[data-pagefind-highlight],
   to {
     opacity: 1;
   }
-}
-
-/* Screen reader only class */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
 }
 
 /* Tabsets */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -841,9 +841,34 @@ mark[data-pagefind-highlight],
   opacity: 0.9;
 }
 
+#image-lightbox {
+  transition: opacity 0.2s ease-out;
+}
+
 #image-lightbox img {
   border-radius: 0.5rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  animation: lightbox-zoom 0.2s ease-out;
+}
+
+#image-lightbox iframe {
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  animation: lightbox-zoom 0.2s ease-out;
+  width: 90vw;
+  height: 90vh;
+  background: white;
+}
+
+@keyframes lightbox-zoom {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 /* Tabsets */

--- a/assets/js/image-lightbox.js
+++ b/assets/js/image-lightbox.js
@@ -29,8 +29,8 @@
           <p class="text-sm mt-2">The file may not exist or cannot be displayed.</p>
         </div>
       </div>
-      <img id="lightbox-image" class="max-w-[95vw] max-h-[95vh] md:max-w-[90vw] md:max-h-[90vh] object-contain" alt="">
-      <iframe id="lightbox-pdf" class="max-w-[95vw] max-h-[95vh] md:max-w-[90vw] md:max-h-[90vh] w-full h-full hidden" frameborder="0" title="PDF viewer"></iframe>
+      <img id="lightbox-image" class="max-w-[95vw] max-h-[95vh] md:max-w-[90vw] md:max-h-[90vh] object-contain touch-pan-x touch-pan-y touch-pinch-zoom" alt="">
+      <iframe id="lightbox-pdf" class="w-[95vw] h-[95vh] md:w-[90vw] md:h-[90vh] bg-white hidden" frameborder="0" title="PDF viewer"></iframe>
       <div id="lightbox-announcement" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
     </div>
   `;

--- a/assets/js/image-lightbox.js
+++ b/assets/js/image-lightbox.js
@@ -30,7 +30,7 @@
         </div>
       </div>
       <img id="lightbox-image" class="max-w-[95vw] max-h-[95vh] md:max-w-[90vw] md:max-h-[90vh] object-contain" alt="">
-      <iframe id="lightbox-pdf" class="max-w-[95vw] max-h-[95vh] md:max-w-[90vw] md:max-h-[90vh] w-full h-full hidden" frameborder="0" title="PDF viewer" sandbox="allow-same-origin allow-scripts"></iframe>
+      <iframe id="lightbox-pdf" class="max-w-[95vw] max-h-[95vh] md:max-w-[90vw] md:max-h-[90vh] w-full h-full hidden" frameborder="0" title="PDF viewer"></iframe>
       <div id="lightbox-announcement" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
     </div>
   `;

--- a/assets/js/image-lightbox.js
+++ b/assets/js/image-lightbox.js
@@ -14,24 +14,45 @@
       </svg>
     </button>
     <img id="lightbox-image" class="max-w-[90vw] max-h-[90vh] object-contain" alt="">
+    <iframe id="lightbox-pdf" class="max-w-[90vw] max-h-[90vh] w-full h-full hidden" frameborder="0"></iframe>
   `;
   document.body.appendChild(lightbox);
 
   const lightboxImg = document.getElementById('lightbox-image');
+  const lightboxPdf = document.getElementById('lightbox-pdf');
   const closeBtn = document.getElementById('lightbox-close');
 
-  // Find all images in prose content
-  const proseImages = document.querySelectorAll('.prose img:not(a img)');
+  // Find all images in prose content and cheatsheet thumbnails
+  const proseImages = document.querySelectorAll('.prose img:not(a img), .cheatsheet-thumbnail img');
 
   proseImages.forEach(img => {
+    // Skip images with no-lightbox class
+    if (img.classList.contains('no-lightbox')) {
+      return;
+    }
+
     // Make images clickable
     img.style.cursor = 'pointer';
     img.setAttribute('role', 'button');
     img.setAttribute('tabindex', '0');
 
     img.addEventListener('click', function() {
-      lightboxImg.src = this.src;
-      lightboxImg.alt = this.alt || '';
+      // Check if this is a cheatsheet thumbnail with a PDF
+      const pdfUrl = this.dataset.pdfUrl;
+
+      if (pdfUrl) {
+        // Show PDF in iframe
+        lightboxPdf.src = pdfUrl;
+        lightboxPdf.classList.remove('hidden');
+        lightboxImg.classList.add('hidden');
+      } else {
+        // Show image
+        lightboxImg.src = this.src;
+        lightboxImg.alt = this.alt || '';
+        lightboxImg.classList.remove('hidden');
+        lightboxPdf.classList.add('hidden');
+      }
+
       lightbox.classList.remove('hidden');
       lightbox.classList.add('flex');
       document.body.style.overflow = 'hidden';
@@ -48,9 +69,16 @@
 
   // Close lightbox
   function closeLightbox() {
-    lightbox.classList.add('hidden');
-    lightbox.classList.remove('flex');
-    document.body.style.overflow = '';
+    lightbox.style.opacity = '0';
+    setTimeout(function() {
+      lightbox.classList.add('hidden');
+      lightbox.classList.remove('flex');
+      lightbox.style.opacity = '';
+      document.body.style.overflow = '';
+      // Clear sources
+      lightboxImg.src = '';
+      lightboxPdf.src = '';
+    }, 200);
   }
 
   closeBtn.addEventListener('click', closeLightbox);

--- a/assets/js/image-lightbox.js
+++ b/assets/js/image-lightbox.js
@@ -8,22 +8,57 @@
   lightbox.id = 'image-lightbox';
   lightbox.className = 'fixed inset-0 z-50 hidden items-center justify-center bg-blue-100/80 transition-opacity';
   lightbox.innerHTML = `
-    <button id="lightbox-close" class="absolute top-4 right-4 text-gray-700 text-4xl font-light hover:text-gray-900 transition-colors z-10" aria-label="Close lightbox">
-      <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-      </svg>
-    </button>
-    <img id="lightbox-image" class="max-w-[90vw] max-h-[90vh] object-contain" alt="">
-    <iframe id="lightbox-pdf" class="max-w-[90vw] max-h-[90vh] w-full h-full hidden" frameborder="0"></iframe>
+    <div role="dialog" aria-modal="true" aria-label="Image lightbox" class="contents">
+      <button id="lightbox-close" class="absolute top-4 right-4 text-gray-700 text-4xl font-light hover:text-gray-900 transition-colors z-10" aria-label="Close lightbox">
+        <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+        </svg>
+      </button>
+      <div id="lightbox-loading" class="absolute inset-0 flex items-center justify-center text-gray-600 hidden" aria-live="polite">
+        <div class="text-center">
+          <svg class="animate-spin h-12 w-12 mx-auto mb-2" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          <span>Loading...</span>
+        </div>
+      </div>
+      <div id="lightbox-error" class="absolute inset-0 flex items-center justify-center text-red-600 hidden" role="alert" aria-live="assertive">
+        <div class="text-center">
+          <p class="text-lg font-medium">Failed to load PDF</p>
+          <p class="text-sm mt-2">The file may not exist or cannot be displayed.</p>
+        </div>
+      </div>
+      <img id="lightbox-image" class="max-w-[95vw] max-h-[95vh] md:max-w-[90vw] md:max-h-[90vh] object-contain" alt="">
+      <iframe id="lightbox-pdf" class="max-w-[95vw] max-h-[95vh] md:max-w-[90vw] md:max-h-[90vh] w-full h-full hidden" frameborder="0" title="PDF viewer" sandbox="allow-same-origin allow-scripts"></iframe>
+      <div id="lightbox-announcement" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
+    </div>
   `;
   document.body.appendChild(lightbox);
 
   const lightboxImg = document.getElementById('lightbox-image');
   const lightboxPdf = document.getElementById('lightbox-pdf');
   const closeBtn = document.getElementById('lightbox-close');
+  const loadingIndicator = document.getElementById('lightbox-loading');
+  const errorIndicator = document.getElementById('lightbox-error');
+  const announcement = document.getElementById('lightbox-announcement');
+  let isTransitioning = false;
+  let lastFocusedElement = null;
+  let pdfLoadTimeout = null;
 
-  // Find all images in prose content and cheatsheet thumbnails
-  const proseImages = document.querySelectorAll('.prose img:not(a img), .cheatsheet-thumbnail img');
+  // Constants
+  const TRANSITION_DURATION = 200;
+  const FOCUS_DELAY = 100;
+  const PDF_TIMEOUT = 10000;
+
+  // Helper to hide all indicators
+  function hideIndicators() {
+    errorIndicator.classList.add('hidden');
+    loadingIndicator.classList.add('hidden');
+  }
+
+  // Find all images in prose content and cheatsheet thumbnails (excluding linked images)
+  const proseImages = document.querySelectorAll('.prose img:not(a img), .cheatsheet-thumbnail img:not(a img)');
 
   proseImages.forEach(img => {
     // Skip images with no-lightbox class
@@ -37,25 +72,72 @@
     img.setAttribute('tabindex', '0');
 
     img.addEventListener('click', function() {
+      // Prevent rapid clicks during transition
+      if (isTransitioning) return;
+
+      // Save current focus
+      lastFocusedElement = document.activeElement;
+
       // Check if this is a cheatsheet thumbnail with a PDF
       const pdfUrl = this.dataset.pdfUrl;
 
+      // Clear any existing timeout
+      if (pdfLoadTimeout) {
+        clearTimeout(pdfLoadTimeout);
+        pdfLoadTimeout = null;
+      }
+
+      // Hide error/loading indicators
+      hideIndicators();
+
       if (pdfUrl) {
+        // Show loading indicator
+        loadingIndicator.classList.remove('hidden');
+
         // Show PDF in iframe
         lightboxPdf.src = pdfUrl;
         lightboxPdf.classList.remove('hidden');
         lightboxImg.classList.add('hidden');
+
+        // Handle PDF load
+        lightboxPdf.onload = function() {
+          loadingIndicator.classList.add('hidden');
+          announcement.textContent = 'PDF loaded';
+        };
+
+        // Handle PDF error
+        lightboxPdf.onerror = function() {
+          loadingIndicator.classList.add('hidden');
+          errorIndicator.classList.remove('hidden');
+          announcement.textContent = 'Failed to load PDF';
+        };
+
+        // Timeout for slow loads
+        pdfLoadTimeout = setTimeout(function() {
+          if (!loadingIndicator.classList.contains('hidden')) {
+            hideIndicators();
+            errorIndicator.classList.remove('hidden');
+            announcement.textContent = 'PDF load timeout';
+          }
+          pdfLoadTimeout = null;
+        }, PDF_TIMEOUT);
       } else {
         // Show image
         lightboxImg.src = this.src;
         lightboxImg.alt = this.alt || '';
         lightboxImg.classList.remove('hidden');
         lightboxPdf.classList.add('hidden');
+        announcement.textContent = 'Image opened in lightbox';
       }
 
       lightbox.classList.remove('hidden');
       lightbox.classList.add('flex');
       document.body.style.overflow = 'hidden';
+
+      // Focus close button for accessibility
+      setTimeout(function() {
+        closeBtn.focus();
+      }, FOCUS_DELAY);
     });
 
     // Keyboard support
@@ -69,16 +151,55 @@
 
   // Close lightbox
   function closeLightbox() {
+    if (isTransitioning) return;
+    isTransitioning = true;
+
+    announcement.textContent = 'Lightbox closed';
     lightbox.style.opacity = '0';
+
+    // Clear pending timeout
+    if (pdfLoadTimeout) {
+      clearTimeout(pdfLoadTimeout);
+      pdfLoadTimeout = null;
+    }
+
     setTimeout(function() {
       lightbox.classList.add('hidden');
       lightbox.classList.remove('flex');
       lightbox.style.opacity = '';
       document.body.style.overflow = '';
-      // Clear sources
+
+      // Clear sources and stop any loading
       lightboxImg.src = '';
+
+      // Stop PDF loading (cross-browser)
+      try {
+        if (lightboxPdf.contentWindow) {
+          if (lightboxPdf.contentWindow.stop) {
+            lightboxPdf.contentWindow.stop();
+          } else if (lightboxPdf.contentWindow.document && lightboxPdf.contentWindow.document.execCommand) {
+            lightboxPdf.contentWindow.document.execCommand('Stop');
+          }
+        }
+      } catch (e) {
+        // Cross-origin iframe access might throw, ignore
+      }
       lightboxPdf.src = '';
-    }, 200);
+
+      // Hide indicators
+      hideIndicators();
+
+      // Reset image transform
+      lightboxImg.style.transform = '';
+
+      // Restore focus
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+
+      isTransitioning = false;
+    }, TRANSITION_DURATION);
   }
 
   closeBtn.addEventListener('click', closeLightbox);
@@ -90,10 +211,63 @@
     }
   });
 
-  // Close on Escape key
+  // Close on Escape key and handle focus trap
   document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape' && !lightbox.classList.contains('hidden')) {
+    if (lightbox.classList.contains('hidden')) return;
+
+    if (e.key === 'Escape') {
       closeLightbox();
     }
+
+    // Focus trap - keep focus within lightbox
+    if (e.key === 'Tab') {
+      const focusableElements = lightbox.querySelectorAll('button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      const firstFocusable = focusableElements[0];
+      const lastFocusable = focusableElements[focusableElements.length - 1];
+
+      if (e.shiftKey) {
+        // Shift + Tab
+        if (document.activeElement === firstFocusable) {
+          e.preventDefault();
+          lastFocusable.focus();
+        }
+      } else {
+        // Tab
+        if (document.activeElement === lastFocusable) {
+          e.preventDefault();
+          firstFocusable.focus();
+        }
+      }
+    }
+  });
+
+  // Enable panning for images on mobile
+  let panning = false;
+  let pointX = 0;
+  let pointY = 0;
+  let start = { x: 0, y: 0 };
+
+  lightboxImg.addEventListener('touchstart', function(e) {
+    if (e.touches.length === 1) {
+      start = { x: e.touches[0].clientX - pointX, y: e.touches[0].clientY - pointY };
+      panning = true;
+    }
+  });
+
+  lightboxImg.addEventListener('touchmove', function(e) {
+    if (panning && e.touches.length === 1) {
+      e.preventDefault();
+      pointX = e.touches[0].clientX - start.x;
+      pointY = e.touches[0].clientY - start.y;
+      this.style.transform = `translate(${pointX}px, ${pointY}px)`;
+    }
+  });
+
+  lightboxImg.addEventListener('touchend', function() {
+    panning = false;
+    // Reset position on release for simplicity
+    pointX = 0;
+    pointY = 0;
+    this.style.transform = '';
   });
 })();

--- a/content/resources/cheatsheets/data-import/_index.md
+++ b/content/resources/cheatsheets/data-import/_index.md
@@ -3,6 +3,7 @@ title: Importing data with the tidyverse
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Learn about readr, readxl, and haven.
 download_url: data-import.pdf
 people:

--- a/content/resources/cheatsheets/data-transformation/_index.md
+++ b/content/resources/cheatsheets/data-transformation/_index.md
@@ -3,6 +3,7 @@ title: Data transformation with dplyr
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for data transformation with dplyr.
 download_url: data-transformation.pdf
 thumbnails:

--- a/content/resources/cheatsheets/data-visualization/_index.md
+++ b/content/resources/cheatsheets/data-visualization/_index.md
@@ -3,6 +3,7 @@ title: Data visualization with ggplot2
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for data visualization with ggplot2.
 download_url: data-visualization.pdf
 thumbnails:

--- a/content/resources/cheatsheets/factors/_index.md
+++ b/content/resources/cheatsheets/factors/_index.md
@@ -3,6 +3,7 @@ title: Factors with forcats
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for factors with forcats.
 download_url: factors.pdf
 thumbnails:

--- a/content/resources/cheatsheets/great-tables/_index.md
+++ b/content/resources/cheatsheets/great-tables/_index.md
@@ -3,6 +3,7 @@ title: Great Tables
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for great tables.
 download_url: great-tables.pdf
 thumbnails:

--- a/content/resources/cheatsheets/gt/_index.md
+++ b/content/resources/cheatsheets/gt/_index.md
@@ -3,6 +3,7 @@ title: gt
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for gt.
 download_url: gt.pdf
 thumbnails:

--- a/content/resources/cheatsheets/keras/_index.md
+++ b/content/resources/cheatsheets/keras/_index.md
@@ -3,6 +3,7 @@ title: Deep Learning with Keras
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for deep learning with keras.
 download_url: keras.pdf
 thumbnails:

--- a/content/resources/cheatsheets/lubridate/_index.md
+++ b/content/resources/cheatsheets/lubridate/_index.md
@@ -3,6 +3,7 @@ title: Dates and times with lubridate
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for dates and times with lubridate.
 download_url: lubridate.pdf
 thumbnails:

--- a/content/resources/cheatsheets/ml-create-models/_index.md
+++ b/content/resources/cheatsheets/ml-create-models/_index.md
@@ -5,6 +5,7 @@ resource_type: cheatsheet
 date: '2026-04-09'
 description: Quick reference guide for create models with parsnip.
 download_url: ml-create-models.pdf
+lightbox: true
 software:
 - parsnip
 languages:

--- a/content/resources/cheatsheets/ml-preprocessing-data/_index.md
+++ b/content/resources/cheatsheets/ml-preprocessing-data/_index.md
@@ -3,6 +3,7 @@ title: Preprocessing data with recipes
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Get your data ready for modeling using pipable sequences of feature engineering steps with recipes.
 download_url: ml-preprocessing-data.pdf
 thumbnails:

--- a/content/resources/cheatsheets/nlp-with-llms/_index.md
+++ b/content/resources/cheatsheets/nlp-with-llms/_index.md
@@ -3,6 +3,7 @@ title: Natural Language Processing using LLMs in R & Python
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for natural language processing using llms in r
   & python.
 download_url: nlp-with-llms.pdf

--- a/content/resources/cheatsheets/package-development/_index.md
+++ b/content/resources/cheatsheets/package-development/_index.md
@@ -3,6 +3,7 @@ title: Package Development
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for package development.
 download_url: package-development.pdf
 thumbnails:

--- a/content/resources/cheatsheets/plotnine/_index.md
+++ b/content/resources/cheatsheets/plotnine/_index.md
@@ -3,6 +3,7 @@ title: Data visualization with Plotnine
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for data visualization with plotnine.
 download_url: plotnine.pdf
 thumbnails:

--- a/content/resources/cheatsheets/plumber/_index.md
+++ b/content/resources/cheatsheets/plumber/_index.md
@@ -3,6 +3,7 @@ title: REST APIs with plumber
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for rest apis with plumber.
 download_url: plumber.pdf
 thumbnails:

--- a/content/resources/cheatsheets/posit-team/_index.md
+++ b/content/resources/cheatsheets/posit-team/_index.md
@@ -3,6 +3,7 @@ title: Posit Team
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for posit team.
 download_url: posit-team.pdf
 thumbnails:

--- a/content/resources/cheatsheets/positron/_index.md
+++ b/content/resources/cheatsheets/positron/_index.md
@@ -3,6 +3,7 @@ title: Positron
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for positron.
 download_url: positron.pdf
 thumbnails:

--- a/content/resources/cheatsheets/purrr/_index.md
+++ b/content/resources/cheatsheets/purrr/_index.md
@@ -3,6 +3,7 @@ title: Apply functions with purrr
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for apply functions with purrr.
 download_url: purrr.pdf
 thumbnails:

--- a/content/resources/cheatsheets/quarto/_index.md
+++ b/content/resources/cheatsheets/quarto/_index.md
@@ -3,6 +3,7 @@ title: Publish and Share with Quarto
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for publish and share with quarto.
 download_url: quarto.pdf
 thumbnails:

--- a/content/resources/cheatsheets/reticulate/_index.md
+++ b/content/resources/cheatsheets/reticulate/_index.md
@@ -3,6 +3,7 @@ title: Use Python with R with reticulate
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for use python with r with reticulate.
 download_url: reticulate.pdf
 thumbnails:

--- a/content/resources/cheatsheets/rmarkdown/_index.md
+++ b/content/resources/cheatsheets/rmarkdown/_index.md
@@ -3,6 +3,7 @@ title: rmarkdown
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for rmarkdown.
 download_url: rmarkdown.pdf
 thumbnails:

--- a/content/resources/cheatsheets/rstudio-ide/_index.md
+++ b/content/resources/cheatsheets/rstudio-ide/_index.md
@@ -3,6 +3,7 @@ title: RStudio IDE
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for rstudio ide.
 download_url: rstudio-ide.pdf
 thumbnails:

--- a/content/resources/cheatsheets/shiny-python/_index.md
+++ b/content/resources/cheatsheets/shiny-python/_index.md
@@ -3,6 +3,7 @@ title: Shiny for Python
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for shiny for python.
 download_url: shiny-python.pdf
 thumbnails:

--- a/content/resources/cheatsheets/shiny/_index.md
+++ b/content/resources/cheatsheets/shiny/_index.md
@@ -3,6 +3,7 @@ title: Shiny for R
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for shiny for r.
 download_url: shiny.pdf
 thumbnails:

--- a/content/resources/cheatsheets/shinychat/_index.md
+++ b/content/resources/cheatsheets/shinychat/_index.md
@@ -3,6 +3,7 @@ title: AI chatbots with shinychat
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for ai chatbots with shinychat.
 download_url: shinychat.pdf
 thumbnails:

--- a/content/resources/cheatsheets/sparklyr/_index.md
+++ b/content/resources/cheatsheets/sparklyr/_index.md
@@ -3,6 +3,7 @@ title: Data science in Spark with sparklyr
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for data science in spark with sparklyr.
 download_url: sparklyr.pdf
 thumbnails:

--- a/content/resources/cheatsheets/strings/_index.md
+++ b/content/resources/cheatsheets/strings/_index.md
@@ -3,6 +3,7 @@ title: String manipulation with stringr
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for string manipulation with stringr.
 download_url: strings.pdf
 thumbnails:

--- a/content/resources/cheatsheets/tidyr/_index.md
+++ b/content/resources/cheatsheets/tidyr/_index.md
@@ -3,6 +3,7 @@ title: Data tidying with tidyr
 image: page-1.png
 resource_type: cheatsheet
 date: '2026-02-25'
+lightbox: true
 description: Quick reference guide for data tidying with tidyr.
 download_url: tidyr.pdf
 thumbnails:

--- a/layouts/partials/extended_footer.html
+++ b/layouts/partials/extended_footer.html
@@ -37,7 +37,13 @@
 
 {{ if .Params.asciinema }}{{ partial "asciinema.html" . }}{{ end }}
 
-{{- /* image-lightbox.js disabled */ -}}
+{{- if .Params.lightbox }}
+{{- $jsLightbox := resources.Get "js/image-lightbox.js" -}}
+{{- if not hugo.IsDevelopment }}
+  {{- $jsLightbox = $jsLightbox | minify | fingerprint -}}
+{{ end -}}
+<script src="{{ $jsLightbox.RelPermalink }}" defer></script>
+{{ end -}}
 
 {{- if (findRE "panel-tabset-tabby" .Content 1) }}
 {{- $jsTabby := resources.Get "js/tabby.min.js" -}}

--- a/layouts/resources/term.html
+++ b/layouts/resources/term.html
@@ -250,13 +250,21 @@
       {{- /* Thumbnails */ -}}
       {{ with .Params.thumbnails }}
       <div class="mt-6">
-        <div class="flex gap-4 overflow-x-auto pb-2">
+        <div class="flex gap-4 overflow-x-auto pb-2 cheatsheet-thumbnail">
           {{ range . }}
           {{ $thumbnail := $.Resources.Get . }}
           {{ if $thumbnail }}
+          {{ $pdfUrl := "" }}
+          {{ with $.Params.download_url }}
+            {{ $pdf := $.Resources.Get . }}
+            {{ if $pdf }}
+              {{ $pdfUrl = $pdf.RelPermalink }}
+            {{ end }}
+          {{ end }}
           <div class="shrink-0">
             <img src="{{ $thumbnail.RelPermalink }}" alt="Page preview"
-              class="h-48 w-auto rounded-lg border border-gray-300" loading="lazy" />
+              class="h-48 w-auto rounded-lg border border-gray-300" loading="lazy"
+              {{ if $pdfUrl }}data-pdf-url="{{ $pdfUrl }}"{{ end }} />
           </div>
           {{ end }}
           {{ end }}

--- a/layouts/resources/term.html
+++ b/layouts/resources/term.html
@@ -249,23 +249,27 @@
     {{ if eq .Params.resource_type "cheatsheet" }}
       {{- /* Thumbnails */ -}}
       {{ with .Params.thumbnails }}
+      {{ $pdfUrl := "" }}
+      {{ with $.Params.download_url }}
+        {{ $pdf := $.Resources.Get . }}
+        {{ if $pdf }}
+          {{ $pdfUrl = $pdf.RelPermalink }}
+        {{ else }}
+          {{ warnf "PDF not found: %s for page %s" . $.File.Path }}
+        {{ end }}
+      {{ end }}
       <div class="mt-6">
         <div class="flex gap-4 overflow-x-auto pb-2 cheatsheet-thumbnail">
           {{ range . }}
           {{ $thumbnail := $.Resources.Get . }}
           {{ if $thumbnail }}
-          {{ $pdfUrl := "" }}
-          {{ with $.Params.download_url }}
-            {{ $pdf := $.Resources.Get . }}
-            {{ if $pdf }}
-              {{ $pdfUrl = $pdf.RelPermalink }}
-            {{ end }}
-          {{ end }}
           <div class="shrink-0">
             <img src="{{ $thumbnail.RelPermalink }}" alt="Page preview"
               class="h-48 w-auto rounded-lg border border-gray-300" loading="lazy"
               {{ if $pdfUrl }}data-pdf-url="{{ $pdfUrl }}"{{ end }} />
           </div>
+          {{ else }}
+            {{ warnf "Thumbnail not found: %s for page %s" . $.File.Path }}
           {{ end }}
           {{ end }}
         </div>

--- a/layouts/resources/term.html
+++ b/layouts/resources/term.html
@@ -260,16 +260,16 @@
       {{ end }}
       <div class="mt-6">
         <div class="flex gap-4 overflow-x-auto pb-2 cheatsheet-thumbnail">
-          {{ range . }}
-          {{ $thumbnail := $.Resources.Get . }}
+          {{ range $index, $element := . }}
+          {{ $thumbnail := $.Resources.Get $element }}
           {{ if $thumbnail }}
           <div class="shrink-0">
             <img src="{{ $thumbnail.RelPermalink }}" alt="Page preview"
               class="h-48 w-auto rounded-lg border border-gray-300" loading="lazy"
-              {{ if $pdfUrl }}data-pdf-url="{{ $pdfUrl }}"{{ end }} />
+              {{ if $pdfUrl }}data-pdf-url="{{ $pdfUrl }}#page={{ add $index 1 }}"{{ end }} />
           </div>
           {{ else }}
-            {{ warnf "Thumbnail not found: %s for page %s" . $.File.Path }}
+            {{ warnf "Thumbnail not found: %s for page %s" $element $.File.Path }}
           {{ end }}
           {{ end }}
         </div>


### PR DESCRIPTION
## Summary
- Add opt-in image lightbox functionality via `lightbox: true` frontmatter
- Display full PDFs in lightbox for cheatsheet thumbnails instead of low-res images
- Each thumbnail opens to its corresponding PDF page using #page=N fragments
- Enhance code copy button styling with improved colors and animations

## Features
### Lightbox
- Custom-built lightbox with accessibility features (ARIA roles, focus management, keyboard navigation)
- Opens regular images in modal view for blog posts and other content
- Opens full PDF in modal for cheatsheet thumbnails (click thumbnail 1 → PDF page 1, etc.)
- Loading indicator and error handling for PDF display
- Mobile touch panning support
- Smooth animations and transitions

### Code Copy Button
- Updated icon colors (gray-400 default, gray-800 hover)
- Green checkmark on successful copy
- Animated checkmark "draw-in" effect
- "Copied!" tooltip positioned above button

## Test plan
- [ ] Test lightbox on blog post images (opens image modal)
- [ ] Test lightbox on cheatsheet thumbnails (opens PDF to correct page)
- [ ] Verify PDF loading indicator appears and disappears correctly
- [ ] Test error handling if PDF fails to load
- [ ] Verify mobile touch panning works on images
- [ ] Test keyboard navigation (Tab, Escape) in lightbox
- [ ] Verify focus returns to trigger element on close
- [ ] Test code copy button colors and animation
- [ ] Verify "Copied!" tooltip appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)