### PR TITLE
Discretize CODEOWNERS by path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,55 @@
-* @cwickham @jeroenjanssens @ivelasq @gregswinehart
+# CODEOWNERS for posit-dev/open-source-website
+#
+# Owners listed here are automatically requested for review when a PR touches
+# files they own. Because the "Protect main" ruleset has "Require review from
+# Code Owners" enabled, an owner's approval is REQUIRED before the PR can merge.
+#
+# Most content — including new blog posts — has no code owner. The author is
+# responsible for soliciting an approving review from anyone with Write access,
+# as required by branch protection. Code owners are reserved for code, the Hugo
+# template, automation, and a few maintained files.
+#
+# Only the LAST matching pattern applies to a given file — owners do not stack
+# across rules.
+
+# Default: the core maintainers own everything not matched by a rule below.
+# Covers site config (hugo.toml, _quarto.yml, package.json, justfile, …), data/,
+# archetypes/, scripts/, .github/, and all content areas except new blog posts.
+* @cwickham @jeroenjanssens @ivelasq
+
+# --- Code, template & infrastructure (discretized by area) ---
+
+# Hugo templates — Jeroen is the required reviewer for template changes.
+/layouts/ @jeroenjanssens
+
+# Styling and static assets — Greg and Jeroen. static/blog/ holds per-post
+# assets (e.g. rendered slide HTML), so it stays unowned like blog posts.
+/assets/ @gregswinehart @jeroenjanssens
+/static/ @gregswinehart @jeroenjanssens
+/static/blog/
+
+# --- Content ---
+
+# Events — Isabella is the required reviewer.
+/content/events/ @ivelasq
+
+# Resources (videos, cheatsheets, …) — Isabella and Jeroen.
+/content/resources/ @ivelasq @jeroenjanssens
+
+# Software pages — Jeroen.
+/content/software/ @jeroenjanssens
+
+# People profiles — Isabella and Jeroen.
+/content/people/ @ivelasq @jeroenjanssens
+
+# --- Blog ---
+
+# New posts live in content/blog/<slug>/ and have NO code owner: the author
+# solicits an approving review from anyone with Write access. content/blog/all.md
+# and the content/blog/q/** project listing pages are likewise unowned.
+/content/blog/
+
+# Ported posts and the maintained blog meta files require Charlotte's review.
+/content/blog/ported/ @cwickham
+/content/blog/_*.md @cwickham
+/content/blog/CLAUDE.md @cwickham

--- a/.github/workflows/blog-checklist.yml
+++ b/.github/workflows/blog-checklist.yml
@@ -35,7 +35,7 @@ jobs:
           <!-- blog-checklist -->
           ## Publishing checklist
 
-          - [ ] **Get a review** — request at least one reviewer on this PR
+          - [ ] **Get a review** — you're responsible for requesting one. Any colleague with Write access can approve; if your PR touches files outside a post folder, the assigned code owner's approval is also required before merging
           - [ ] **Check your post** — once the deploy preview is ready, a comment will appear with direct links to your post
           - [ ] **Check the blog listing** — confirm your post appears with the correct title, image, and description
           - [ ] **Merge** — once everything looks good and you have an approving review, merge to `main`

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -144,7 +144,9 @@ Push your branch and open a PR against `main`. A bot will post a publishing chec
 
 ### Get a review
 
-Request at least one reviewer — they can check content, frontmatter, and the rendered preview.
+Branch protection requires one approving review from someone with **Write access** before you can merge — and you're responsible for requesting it. Anyone on the Everyone team can approve, so ask a colleague to check the content, frontmatter, and rendered preview.
+
+A new post (everything under `content/blog/<slug>/`) has no required reviewer, so any Write-access approval unblocks the merge. But if your PR also touches files *outside* a post folder — ported posts, the blog meta files (`_*.md`, `CLAUDE.md`), templates, or scripts — GitHub adds the relevant code owner as a required reviewer, and the PR stays blocked until **they** approve.
 
 ### Check the preview
 


### PR DESCRIPTION
## What this does

Replaces the single catch-all rule (`* @cwickham @jeroenjanssens @ivelasq @gregswinehart`, which requested all four reviewers on every PR) with **per-area code owners**, so a PR only pulls in the relevant reviewer(s). New blog posts get no code owner at all — the author solicits an approving review from anyone with Write access, which branch protection already requires.

Also updates the blog authoring guide ("Get a review") and the blog checklist workflow to explain the review policy.

## Reviewers by path

CODEOWNERS uses **last-match-wins**, and where two owners are listed **either one's** approval clears the gate.

### Code, template & assets
| Path | Code owner(s) |
|---|---|
| `/layouts/` (Hugo template) | `@jeroenjanssens` |
| `/assets/` | `@gregswinehart` `@jeroenjanssens` |
| `/static/` | `@gregswinehart` `@jeroenjanssens` |
| `/static/blog/` | *none* (per-post assets) |

### Content
| Path | Code owner(s) |
|---|---|
| `/content/events/` | `@ivelasq` |
| `/content/resources/` | `@ivelasq` `@jeroenjanssens` |
| `/content/software/` | `@jeroenjanssens` |
| `/content/people/` | `@ivelasq` `@jeroenjanssens` |

### Blog
| Path | Code owner(s) |
|---|---|
| `/content/blog/<slug>/` (new posts), `all.md`, `q/**` | *none* — author solicits a Write-access review |
| `/content/blog/ported/` | `@cwickham` |
| `/content/blog/_*.md` | `@cwickham` |
| `/content/blog/CLAUDE.md` | `@cwickham` |

### Everything else (catch-all `*`)
| Path | Code owner(s) |
|---|---|
| Site config (`hugo.toml`, `_quarto.yml`, `package.json`, `justfile`, …), `data/`, `archetypes/`, `scripts/`, `.github/`, and any unlisted content | `@cwickham` `@jeroenjanssens` `@ivelasq` |

## Required to take effect: toggle the ruleset

CODEOWNERS alone only changes **who is auto-requested**. To make code-owner approval **blocking**, the "Protect main" ruleset (id `14879521`) needs `require_code_owner_review` flipped from `false` to `true`. Do this **after this PR merges**, so the new ownership is live first.

Either toggle it in the GitHub UI (Settings → Rules → "Protect main" → "Require review from Code Owners"), or via the API (only that one flag changes):

```sh
gh api --method PUT repos/posit-dev/open-source-website/rulesets/14879521 --input ruleset-update.json
```

Until that flag is on, narrowing CODEOWNERS just changes the auto-requested reviewers, not enforcement.
