### PR TITLE
Sort upcoming events chronologically (soonest first)

### DIFF
--- a/assets/js/search-filter-sort.js
+++ b/assets/js/search-filter-sort.js
@@ -1055,6 +1055,8 @@
         sectionOrder.forEach(section => {
           const sectionItems = filtered.filter(item => item.section === section);
           if (sectionItems.length > 0) {
+            // Upcoming events should be in ascending date order (soonest first)
+            if (section === 'upcoming') sectionItems.reverse();
             grouped.push({ heading: section, items: sectionItems });
           }
         });

--- a/layouts/events/terms.html
+++ b/layouts/events/terms.html
@@ -48,7 +48,7 @@
     {{/* Upcoming Events */}}
     {{ if gt (len $upcomingEvents) 0 }}
     <h2 data-section-heading="upcoming" class="col-span-full text-2xl font-medium text-gray-800">Upcoming Events</h2>
-    {{ range sort $upcomingEvents ".Params.start_date" "desc" }}
+    {{ range sort $upcomingEvents ".Params.start_date" "asc" }}
       {{ partial "item.html" (dict "page" . "hide-badge" true "section" "upcoming") }}
     {{ end }}
     {{ end }}


### PR DESCRIPTION
## Summary
- Upcoming events now display in ascending date order so the soonest event appears first
- Changed both the Hugo template sort and the JS client-side sort for the "upcoming" section
- Current and past event sections remain in descending order (most recent first)

Fixes #341

## Test plan
- [x] Visit `/events/` and verify upcoming events are ordered soonest-first
- [x] Verify current and past sections still show most recent first
- [x] Apply a filter or search, confirm upcoming order is preserved