### PR TITLE
Add Posit.co links and alert banner

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -919,12 +919,20 @@ mark[data-pagefind-highlight],
   font-size: 0.925rem;
 }
 
+.callout > .callout-body:first-child {
+  padding: 0.75rem 1rem;
+}
+
 .callout-body > :first-child {
   margin-top: 0;
 }
 
 .callout-body > :last-child {
   margin-bottom: 0;
+}
+
+.prose .callout a {
+  color: inherit !important;
 }
 
 /* Callout icons via CSS mask-image (decorative, no markup needed) */

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -14,6 +14,17 @@ subtitle = ""
 showReadingTime = false
 images = ["/images/pos-og.png"]
 
+# Site-wide alert banner (appears above navbar)
+# - enabled: set to true to show the banner
+# - id: unique identifier (change to show a new alert to users who dismissed previous ones)
+# - message: supports markdown and raw HTML with Tailwind classes
+# - icon: optional icon name from assets/icons/ (e.g., "calendar", "rss", "world")
+[params.alert]
+enabled = true
+id = "example-2026-07-15"
+message = "**posit::conf is September 14-16 in Houston, TX!**  <span class='block sm:block md:inline ml-0 md:ml-2'>[Register now](https://conf.posit.co/2026/) to attend in person or virtually.</span>"
+icon = ""
+
 [taxonomies]
   tag = 'tags'
   topic = 'topics'

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -21,7 +21,7 @@ images = ["/images/pos-og.png"]
 # - icon: optional icon name from assets/icons/ (e.g., "calendar", "rss", "world")
 [params.alert]
 enabled = true
-id = "example-2026-07-15"
+id = "positconf-2026-07-15"
 message = "**posit::conf is September 14-16 in Houston, TX!**  <span class='block sm:block md:inline ml-0 md:ml-2'>[Register now](https://conf.posit.co/2026/) to attend in person or virtually.</span>"
 icon = ""
 

--- a/content/software/shiny-r/_index.md
+++ b/content/software/shiny-r/_index.md
@@ -70,6 +70,14 @@ external:  # updated automatically, do not edit
   website: https://shiny.posit.co/
 ---
 
+<div class="callout callout-note bg-blue-100 rounded-r-md" role="note" aria-label="Note">
+<div class="callout-body text-base">
+
+Scale and share your Shiny apps securely with <a class="font-semibold" href="https://posit.co/products/enterprise/connect">Posit Connect</a>
+
+</div>
+</div>
+
 Shiny is an R package for building interactive web applications without requiring HTML, CSS, or JavaScript knowledge. It uses a reactive programming model that automatically updates outputs when users change inputs, making it straightforward to transform existing R code into live web apps.
 
 The package provides prebuilt widgets like plots, tables, and controls with an attractive Bootstrap-based design. It includes performance tools like async programming and caching, supports modular code organization to reduce complexity, and integrates seamlessly with R Markdown for embedding apps in documents. A rich ecosystem of extension packages adds capabilities like custom widgets, input validation, and unit testing.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,6 +24,7 @@
   {{- if hugo.IsDevelopment }}
     {{ partial "tailwind-size-indicator.html" }}
   {{ end -}}
+  {{ partial "alert-banner.html" . }}
   <header id="site-header" class="flex flex-none justify-center {{- if $.Site.Params.header.sticky }} sticky top-0{{ end -}} {{ if not .IsHome }}bg-white z-50{{ else }}transition-colors duration-300 z-50{{ end }}" data-is-home="{{ if .IsHome }}true{{ else }}false{{ end }}">
     {{ partial "header.html" . }}
   </header>

--- a/layouts/partials/alert-banner.html
+++ b/layouts/partials/alert-banner.html
@@ -1,7 +1,7 @@
 {{- $alert := site.Params.alert -}}
 {{- if and $alert $alert.enabled $alert.message -}}
 <div id="alert-banner" class="bg-blue-600 text-white hidden relative z-50" data-alert-id="{{ $alert.id | default "default" }}">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 relative">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 relative">
     <div class="flex items-center justify-center gap-3 pr-10">
       {{- if $alert.icon -}}
       <i class="h-5 w-5 flex-none">

--- a/layouts/partials/alert-banner.html
+++ b/layouts/partials/alert-banner.html
@@ -8,7 +8,7 @@
         {{ partial "icon.html" $alert.icon }}
       </i>
       {{- end -}}
-      <p class="text-sm sm:text-base text-center [&_a]:underline [&_a:hover]:no-underline">
+      <p class="text-[15px] text-center [&_a]:underline [&_a:hover]:no-underline">
         {{ $alert.message | markdownify }}
       </p>
     </div>

--- a/layouts/partials/alert-banner.html
+++ b/layouts/partials/alert-banner.html
@@ -1,0 +1,55 @@
+{{- $alert := site.Params.alert -}}
+{{- if and $alert $alert.enabled $alert.message -}}
+<div id="alert-banner" class="bg-blue-600 text-white hidden relative z-50" data-alert-id="{{ $alert.id | default "default" }}">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 relative">
+    <div class="flex items-center justify-center gap-3 pr-10">
+      {{- if $alert.icon -}}
+      <i class="h-5 w-5 flex-none">
+        {{ partial "icon.html" $alert.icon }}
+      </i>
+      {{- end -}}
+      <p class="text-sm sm:text-base text-center [&_a]:underline [&_a:hover]:no-underline">
+        {{ $alert.message | markdownify }}
+      </p>
+    </div>
+    <button id="alert-banner-close" type="button" class="absolute right-4 sm:right-6 top-1/2 -translate-y-1/2 p-2 hover:bg-blue-700 rounded transition-colors" aria-label="Dismiss alert">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M18 6l-12 12" />
+        <path d="M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+</div>
+
+<script>
+(function() {
+  const banner = document.getElementById('alert-banner');
+  const closeBtn = document.getElementById('alert-banner-close');
+
+  if (!banner || !closeBtn) return;
+
+  const alertId = banner.getAttribute('data-alert-id');
+  const storageKey = 'alert-banner-dismissed-' + alertId;
+
+  // Check if this alert was previously dismissed
+  try {
+    if (!localStorage.getItem(storageKey)) {
+      banner.classList.remove('hidden');
+    }
+  } catch (e) {
+    // localStorage might be disabled/blocked, show banner anyway
+    banner.classList.remove('hidden');
+  }
+
+  // Handle close button
+  closeBtn.addEventListener('click', function() {
+    banner.classList.add('hidden');
+    try {
+      localStorage.setItem(storageKey, 'true');
+    } catch (e) {
+      // localStorage disabled/blocked, banner will show again on reload
+    }
+  });
+})();
+</script>
+{{- end -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,9 +1,9 @@
 <footer class="w-full bg-white text-gray-700 mt-12 border-t border-blue-200">
   <div class="flex flex-col w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-18 pb-10">
     <!-- Main Footer Content -->
-    <div class="grid grid-cols-1 md:grid-cols-5 gap-8 mb-14">
+    <div class="grid grid-cols-1 md:grid-cols-7 gap-8 mb-14">
       <!-- Brand Column -->
-      <div class="col-span-1 md:col-span-2">
+      <div class="col-span-1 md:col-span-3 md:pr-4 xl:pr-8 2xl:pr-12">
         <a href="{{ relLangURL "" }}" class="inline-block mb-4">
           <span class="">
             {{ partial "responsive_image_fixed.html" (dict "imagePath" "posit-open-source-logo-light.png" "baseHeight" 26 "alt" "Posit Open Source" "class" "h-6.5") }}
@@ -15,58 +15,65 @@
         <p class="text-sm text-gray-600">
           Open source software and tools for data science.
         </p>
+        <p class="text-sm mt-3 text-gray-600">
+          Visit <a class="underline" href="https://posit.co/products">posit.co</a> to learn how our enterprise products allow you to use open source tools securely, more collaboratively, and at scale.
+        </p>
+        
       </div>
 
-      <!-- Navigation Column -->
-      <div class="col-span-1">
-        <h3 class="text-gray-900 font-semibold mb-4">Navigate</h3>
-        <ul class="space-y-2 text-sm">
-          {{ range site.Menus.main }}
-          <li>
-            <a href="{{ .URL }}" class="font-medium hover:text-blue-500 transition-colors">
-              {{ .Name }}
-            </a>
-          </li>
-          {{ end }}
-        </ul>
-      </div>
+      <!-- Navigation and Learn Columns (side-by-side on mobile) -->
+      <div class="col-span-1 md:col-span-2 grid grid-cols-2 gap-8">
+        <!-- Navigation Column -->
+        <div>
+          <h3 class="text-gray-900 font-semibold mb-4">Navigate</h3>
+          <ul class="space-y-2 text-sm">
+            {{ range site.Menus.main }}
+            <li>
+              <a href="{{ .URL }}" class="font-medium hover:text-blue-500 transition-colors">
+                {{ .Name }}
+              </a>
+            </li>
+            {{ end }}
+          </ul>
+        </div>
 
-      <!-- Resources Column -->
-      <div class="col-span-1">
-        <h3 class="text-gray-900 font-semibold mb-4">Learn</h3>
-        <ul class="space-y-2 text-sm">
-          <li>
-            <a href="https://posit.co" target="_blank" rel="noopener" class="hover:text-gray-900 transition-colors">
-              Posit.co
-            </a>
-          </li>
-          <li>
-            <a href="https://posit.co/about/" target="_blank" rel="noopener" class="hover:text-gray-900 transition-colors">
-              About Posit
-            </a>
-          </li>
-          <li>
-            <a href="https://posit.co/support/" target="_blank" rel="noopener" class="hover:text-gray-900 transition-colors">
-              Support
-            </a>
-          </li>
-          <li>
-            <a href="https://github.com/posit-dev" target="_blank" rel="noopener" class="hover:text-gray-900 transition-colors">
-              GitHub
-            </a>
-          </li>
-          <li>
-            <a href="/subscribe/" class="hover:text-gray-900 transition-colors">
-              Subscribe
-            </a>
-          </li>
-        </ul>
+        <!-- Resources Column -->
+        <div>
+          <h3 class="text-gray-900 font-semibold mb-4">Learn</h3>
+          <ul class="space-y-2 text-sm">
+            <li>
+              <a href="https://posit.co" target="_blank" rel="noopener" class="hover:text-gray-900 transition-colors">
+                Posit.co
+              </a>
+            </li>
+            <li>
+              <a href="https://posit.co/about/" target="_blank" rel="noopener" class="hover:text-gray-900 transition-colors">
+                About Posit
+              </a>
+            </li>
+            <li>
+              <a href="https://posit.co/support/" target="_blank" rel="noopener" class="hover:text-gray-900 transition-colors">
+                Support
+              </a>
+            </li>
+            <li>
+              <a href="https://github.com/posit-dev" target="_blank" rel="noopener" class="hover:text-gray-900 transition-colors">
+                GitHub
+              </a>
+            </li>
+            <li>
+              <a href="/subscribe/" class="hover:text-gray-900 transition-colors">
+                Subscribe
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
 
       <!-- Social Column -->
-      <div class="col-span-">
+      <div class="col-span-1 md:col-span-2">
         <h3 class="text-gray-900 font-semibold mb-4">Connect</h3>
-        <div class="flex flex-row gap-4">
+        <div class="flex flex-row flex-wrap gap-4">
           <a href="https://github.com/posit-dev" target="_blank" rel="noopener" title="GitHub" class="text-gray-600 hover:text-gray-900 transition-colors">
             <i class="h-6 w-6 flex-none">{{ partial "icon.html" "brand-github" }}</i>
             <span class="sr-only">GitHub</span>


### PR DESCRIPTION
## Summary

This PR is trying to strengthen the association between Posit's open source tools and our professional products in a way that makes sense for open source users and is not gross.

A few small additions:
- Add Posit.co text and link to footer
<img width="1789" height="1196" alt="Screenshot 2026-07-16 at 2 39 57 PM" src="https://github.com/user-attachments/assets/1ab25774-f2dc-4691-8547-17e7a488df64" />
- Add a callout when one of our professional products might help an open source user
<img width="1102" height="813" alt="Screenshot 2026-07-16 at 4 05 43 PM" src="https://github.com/user-attachments/assets/d0691bce-d326-4984-b14b-e34725923725" />

Also, it includes an alert for times that we'd want to let open source users know that something awesome is happening, like our conference.

- Add dismissable site-wide alert banner component with localStorage persistence
<img width="1789" height="1196" alt="Screenshot 2026-07-16 at 2 39 36 PM" src="https://github.com/user-attachments/assets/23fe1f3c-3208-42cc-8de2-267ca5e61bdd" />

## Test plan
- [ ] Alert banner appears on first visit and can be dismissed
- [ ] Alert banner stays dismissed after page reload (localStorage)
- [ ] Footer layout is responsive and includes Posit.co link
- [ ] Shiny page callout displays with proper link styling
- [ ] Callout links match surrounding text color

🤖 Generated with [Claude Code](https://claude.com/claude-code)