### PR TITLE
Add custom Atom content feeds with rich metadata

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -45,6 +45,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.sha }}
+          # Full history so Hugo's enableGitInfo can derive each page's
+          # last-modified date from its last commit (shallow clones stamp
+          # every file with the same date).
+          fetch-depth: 0
 
       - name: Setup Hugo
         run: |

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -40,10 +40,24 @@ icon = ""
   isPlainText = true
   notAlternative = true
 
+# Custom Atom feed carrying rich metadata (see layouts/partials/atom/).
+# baseName "index.md" + suffix "xml" -> "index.md.xml", kept distinct from the
+# built-in RSS "index.xml" so both coexist per section. isPlainText stops Hugo
+# from HTML-escaping the XML we emit.
+[mediaTypes."application/atom+xml"]
+  suffixes = ["xml"]
+
+[outputFormats.AtomContent]
+  mediaType = "application/atom+xml"
+  baseName = "index.md"
+  isPlainText = true
+  notAlternative = true
+  rel = "alternate"
+
 [outputs]
   home = ['html']
-  section = ['html', 'ItemIndex']
-  taxonomy = ['html', 'ItemIndex']
+  section = ['html', 'ItemIndex', 'AtomContent']
+  taxonomy = ['html', 'ItemIndex', 'AtomContent']
   term = ['html', 'ItemIndex']
   page = ['html']
 

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -1,6 +1,11 @@
 baseURL = 'https://opensource.posit.co'
 languageCode = 'en-us'
 title = 'Posit Open Source'
+# Resolve .Lastmod from each file's last git commit date so the Atom feeds'
+# <updated> reflects real edits (not just the publish date in frontmatter).
+# Requires full git history at build time (fetch-depth: 0 in CI); a shallow
+# clone would stamp every page with the same commit date.
+enableGitInfo = true
 ignoreFiles = ['\.qmd$', '\.ipynb$', '\.Rmd$', '\.Rmarkdown$', 'CLAUDE\.md$', '_porting-notes\.md$', '_editing-ported-posts\.md$', '_link-checks\.md$', '_authoring-guide\.md$', '_external-sources', 'blog/.*/renv/', 'renv\.lock$', '\.Rprofile$', '_metadata\.yml$', '\.bib$', 'shinychat-tool-ui/feature/', '\.venv/', 'uv\.lock$', 'pyproject\.toml$', '\.quarto/', '_extensions/', '_quarto\.yml$', '_lychee/', '\.original$']
 
 [permalinks.page]

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -4,6 +4,7 @@ outputs:
   - html
   - rss
   - ItemIndex
+  - AtomContent
 cascade:
   - Toc: true
 ---

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -4,6 +4,7 @@ outputs:
   - html
   - rss
   - ItemIndex
+  - AtomContent
 cascade:
   outputs:
     - html

--- a/layouts/_default/list.atomcontent.xml
+++ b/layouts/_default/list.atomcontent.xml
@@ -1,0 +1,3 @@
+{{- /* Empty default Atom feed — prevents errors for sections/home that opt into
+  AtomContent output but have no custom feed template. */ -}}
+{{- partial "atom/feed.html" (dict "ctx" . "pages" slice "title" .Title "entry" "atom/entry-blog.html") -}}

--- a/layouts/_default/taxonomy.atomcontent.xml
+++ b/layouts/_default/taxonomy.atomcontent.xml
@@ -1,0 +1,3 @@
+{{- /* Empty default Atom feed for taxonomies that opt into AtomContent output
+  (tags, topics, languages) but have no dedicated content feed. */ -}}
+{{- partial "atom/feed.html" (dict "ctx" . "pages" slice "title" .Title "entry" "atom/entry-blog.html") -}}

--- a/layouts/blog/list.atomcontent.xml
+++ b/layouts/blog/list.atomcontent.xml
@@ -1,0 +1,9 @@
+{{- /* Atom feed of all blog posts, richest metadata, newest first. */ -}}
+{{- $pages := where .RegularPagesRecursive "Section" "blog" -}}
+{{- $pages = $pages.ByDate.Reverse -}}
+{{- partial "atom/feed.html" (dict
+  "ctx" .
+  "pages" $pages
+  "title" (printf "Blog on %s" .Site.Title)
+  "entry" "atom/entry-blog.html"
+) -}}

--- a/layouts/events/taxonomy.atomcontent.xml
+++ b/layouts/events/taxonomy.atomcontent.xml
@@ -1,0 +1,28 @@
+{{- /* Atom feed of all events: upcoming first (start_date asc), then past
+  (start_date desc). Mirrors the ordering of the existing events RSS but emits
+  every event with no limit. */ -}}
+{{- $now := now -}}
+{{- $upcoming := slice -}}
+{{- $past := slice -}}
+{{- range (site.GetPage "/events").Pages -}}
+  {{- $startDate := .Params.start_date -}}
+  {{- if $startDate -}}
+    {{- $start := time $startDate -}}
+    {{- if ge $start.Unix $now.Unix -}}
+      {{- $upcoming = $upcoming | append . -}}
+    {{- else -}}
+      {{- $past = $past | append . -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $past = $past | append . -}}
+  {{- end -}}
+{{- end -}}
+{{- $upcoming = sort $upcoming ".Params.start_date" "asc" -}}
+{{- $past = sort $past ".Params.start_date" "desc" -}}
+{{- $pages := $upcoming | append $past -}}
+{{- partial "atom/feed.html" (dict
+  "ctx" .
+  "pages" $pages
+  "title" (printf "Events on %s" .Site.Title)
+  "entry" "atom/entry-event.html"
+) -}}

--- a/layouts/partials/atom/authors.html
+++ b/layouts/partials/atom/authors.html
@@ -1,0 +1,16 @@
+{{- /*
+  atom/authors.html — Emit native Atom <author> elements from a page's "people"
+  taxonomy terms, each with <name> and an absolute <uri> pointing at the
+  person's page. The <uri> equals that person's <id> in the people feed, so it
+  acts as a foreign key linking items to people.
+
+  Input (dict):
+    "page" — the Page object
+*/ -}}
+{{- $page := .page -}}
+{{- range $page.GetTerms "people" -}}
+      <author>
+        <name>{{ .LinkTitle }}</name>
+        <uri>{{ .Permalink }}</uri>
+      </author>
+{{ end -}}

--- a/layouts/partials/atom/body.html
+++ b/layouts/partials/atom/body.html
@@ -1,0 +1,14 @@
+{{- /*
+  atom/body.html — Emit the page's raw Markdown body (frontmatter stripped) as
+  the standard Atom <content> element, CDATA-wrapped so Markdown/HTML content
+  does not break the XML. type="text/markdown" tells consumers the payload is
+  Markdown rather than plain text or HTML. The "]]>" sequence is split to avoid
+  prematurely closing the CDATA section.
+
+  Input (dict):
+    "page" — the Page object
+*/ -}}
+{{- $page := .page -}}
+{{- $raw := $page.RawContent -}}
+{{- $raw = replace $raw "]]>" "]]]]><![CDATA[>" -}}
+      <content type="text/markdown">{{ printf "<![CDATA[%s]]>" $raw | safeHTML }}</content>

--- a/layouts/partials/atom/entry-blog.html
+++ b/layouts/partials/atom/entry-blog.html
@@ -1,0 +1,29 @@
+{{- /* atom/entry-blog.html — one <entry> for a blog post. vr:type = post. */ -}}
+{{- $page := .page -}}
+  <entry>
+    <id>{{ $page.Permalink }}</id>
+    <title>{{ $page.Title }}</title>
+    <link rel="alternate" href="{{ $page.Permalink }}"/>
+    {{- with $page.Params.date }}
+    <published>{{ (time .).Format "2006-01-02T15:04:05Z07:00" | safeHTML }}</published>
+    {{- end }}
+    <updated>{{ partial "atom/updated.html" (dict "page" $page) | safeHTML }}</updated>
+    {{- with $page.Params.description }}
+    <summary>{{ . | strings.TrimSpace }}</summary>
+    {{- end }}
+    {{ partial "atom/authors.html" (dict "page" $page) -}}
+    {{- range $page.GetTerms "tags" }}
+    <category term="{{ .LinkTitle }}"/>
+    {{- end }}
+    <vr:type>post</vr:type>
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "software" "element" "software") -}}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "languages" "element" "language") -}}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "topics" "element" "topic") -}}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "events" "element" "event") -}}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "resources" "element" "resource") -}}
+    {{- with $page.Params.source }}
+    <vr:source>{{ . }}</vr:source>
+    {{- end }}
+    {{ partial "atom/image.html" (dict "page" $page) -}}
+    {{ partial "atom/body.html" (dict "page" $page) -}}
+  </entry>

--- a/layouts/partials/atom/entry-event.html
+++ b/layouts/partials/atom/entry-event.html
@@ -1,0 +1,45 @@
+{{- /* atom/entry-event.html — one <entry> for an event. vr:type = event. */ -}}
+{{- $page := .page -}}
+  <entry>
+    <id>{{ $page.Permalink }}</id>
+    <title>{{ $page.Title }}</title>
+    <link rel="alternate" href="{{ $page.Permalink }}"/>
+    {{- with $page.Params.website }}
+    <link rel="related" href="{{ . }}"/>
+    {{- end }}
+    {{- with $page.Params.start_date }}
+    <published>{{ (time .).Format "2006-01-02T15:04:05Z07:00" | safeHTML }}</published>
+    {{- end }}
+    {{- /* Events carry start_date/end_date, not a standard date, so Lastmod is
+      often the zero time. Fall back to start_date for a valid <updated>. */ -}}
+    {{- $updated := $page.Lastmod -}}
+    {{- if lt $updated.Year 1970 -}}
+      {{- with $page.Params.start_date }}{{ $updated = time . }}{{ end -}}
+    {{- end }}
+    <updated>{{ $updated.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}</updated>
+    {{- with $page.Params.description }}
+    <summary>{{ . | strings.TrimSpace }}</summary>
+    {{- end }}
+    {{ partial "atom/authors.html" (dict "page" $page) -}}
+    <vr:type>event</vr:type>
+    {{- with $page.Params.event_type }}
+    <vr:event_type>{{ . }}</vr:event_type>
+    {{- end }}
+    {{- with $page.Params.location }}
+    <vr:location>{{ . }}</vr:location>
+    {{- end }}
+    {{- with $page.Params.start_date }}
+    <vr:start_date>{{ time.Format "2006-01-02" . }}</vr:start_date>
+    {{- end }}
+    {{- with $page.Params.end_date }}
+    <vr:end_date>{{ time.Format "2006-01-02" . }}</vr:end_date>
+    {{- end }}
+    {{- with $page.Params.website }}
+    <vr:website>{{ . }}</vr:website>
+    {{- end }}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "software" "element" "software") -}}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "languages" "element" "language") -}}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "resources" "element" "resource") -}}
+    {{ partial "atom/image.html" (dict "page" $page) -}}
+    {{ partial "atom/body.html" (dict "page" $page) -}}
+  </entry>

--- a/layouts/partials/atom/entry-person.html
+++ b/layouts/partials/atom/entry-person.html
@@ -1,0 +1,29 @@
+{{- /* atom/entry-person.html — one <entry> for a person profile. vr:type = person.
+  The <id> (the person's page URL) is the foreign key that blog/event/software
+  <author><uri> and vr:people href values point back to. */ -}}
+{{- $page := .page -}}
+  <entry>
+    <id>{{ $page.Permalink }}</id>
+    <title>{{ $page.Title }}</title>
+    <link rel="alternate" href="{{ $page.Permalink }}"/>
+    <updated>{{ partial "atom/updated.html" (dict "page" $page) | safeHTML }}</updated>
+    {{- with $page.Params.description }}
+    <summary>{{ . | strings.TrimSpace }}</summary>
+    {{- end }}
+    <vr:type>person</vr:type>
+    {{- with $page.Params.role }}
+    <vr:role>{{ . }}</vr:role>
+    {{- end }}
+    {{- with $page.Params.affiliation }}
+    <vr:affiliation>{{ . }}</vr:affiliation>
+    {{- end }}
+    {{- with $page.Params.social }}
+    {{- range $network, $value := . }}
+    {{- with $value }}
+    <vr:social network="{{ $network }}" value="{{ . }}"/>
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{ partial "atom/image.html" (dict "page" $page) -}}
+    {{ partial "atom/body.html" (dict "page" $page) -}}
+  </entry>

--- a/layouts/partials/atom/entry-person.html
+++ b/layouts/partials/atom/entry-person.html
@@ -7,6 +7,11 @@
     <title>{{ $page.Title }}</title>
     <link rel="alternate" href="{{ $page.Permalink }}"/>
     <updated>{{ partial "atom/updated.html" (dict "page" $page) | safeHTML }}</updated>
+    {{- /* A person authors their own profile. */}}
+    <author>
+      <name>{{ $page.Title }}</name>
+      <uri>{{ $page.Permalink }}</uri>
+    </author>
     {{- with $page.Params.description }}
     <summary>{{ . | strings.TrimSpace }}</summary>
     {{- end }}

--- a/layouts/partials/atom/entry-resource.html
+++ b/layouts/partials/atom/entry-resource.html
@@ -1,0 +1,49 @@
+{{- /* atom/entry-resource.html — one <entry> for a resource (cheatsheet, video,
+  tutorial, webinar). vr:type = resource; the specific kind is vr:resource_type. */ -}}
+{{- $page := .page -}}
+{{- $ext := $page.Params.external | default dict -}}
+  <entry>
+    <id>{{ $page.Permalink }}</id>
+    <title>{{ $page.Title }}</title>
+    <link rel="alternate" href="{{ $page.Permalink }}"/>
+    {{- with $page.Params.date }}
+    <published>{{ (time .).Format "2006-01-02T15:04:05Z07:00" | safeHTML }}</published>
+    {{- end }}
+    <updated>{{ partial "atom/updated.html" (dict "page" $page) | safeHTML }}</updated>
+    {{- with $page.Params.description }}
+    <summary>{{ . | strings.TrimSpace }}</summary>
+    {{- end }}
+    <vr:type>resource</vr:type>
+    {{- with $page.Params.resource_type }}
+    <vr:resource_type>{{ . }}</vr:resource_type>
+    {{- end }}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "software" "element" "software") -}}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "languages" "element" "language") -}}
+    {{- if $page.Params.download_url }}
+    {{- with $page.Resources.GetMatch $page.Params.download_url }}
+    <vr:download_url>{{ .Permalink }}</vr:download_url>
+    {{- end }}
+    {{- end }}
+    {{- if eq ($page.Params.resource_type | default "") "video" }}
+    {{- with $ext.url }}
+    <vr:video_url>{{ . }}</vr:video_url>
+    {{- end }}
+    {{- with $ext.duration }}
+    <vr:duration>{{ . }}</vr:duration>
+    {{- end }}
+    {{- with $ext.view_count }}
+    <vr:view_count>{{ . }}</vr:view_count>
+    {{- end }}
+    {{- with $ext.like_count }}
+    <vr:like_count>{{ . }}</vr:like_count>
+    {{- end }}
+    {{- with $ext.comment_count }}
+    <vr:comment_count>{{ . }}</vr:comment_count>
+    {{- end }}
+    {{- with $ext.channel }}
+    <vr:channel>{{ . }}</vr:channel>
+    {{- end }}
+    {{- end }}
+    {{ partial "atom/image.html" (dict "page" $page) -}}
+    {{ partial "atom/body.html" (dict "page" $page) -}}
+  </entry>

--- a/layouts/partials/atom/entry-resource.html
+++ b/layouts/partials/atom/entry-resource.html
@@ -13,6 +13,7 @@
     {{- with $page.Params.description }}
     <summary>{{ . | strings.TrimSpace }}</summary>
     {{- end }}
+    {{ partial "atom/authors.html" (dict "page" $page) -}}
     <vr:type>resource</vr:type>
     {{- with $page.Params.resource_type }}
     <vr:resource_type>{{ . }}</vr:resource_type>

--- a/layouts/partials/atom/entry-software.html
+++ b/layouts/partials/atom/entry-software.html
@@ -18,10 +18,10 @@
     {{- with $page.Params.description }}
     <summary>{{ . | strings.TrimSpace }}</summary>
     {{- end }}
+    {{ partial "atom/authors.html" (dict "page" $page) -}}
     <vr:type>software</vr:type>
     {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "languages" "element" "language") -}}
     {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "topics" "element" "topic") -}}
-    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "people" "element" "person") -}}
     {{- with $page.Params.github }}
     <vr:github>{{ . }}</vr:github>
     {{- end }}

--- a/layouts/partials/atom/entry-software.html
+++ b/layouts/partials/atom/entry-software.html
@@ -1,0 +1,51 @@
+{{- /* atom/entry-software.html — one <entry> for a software project. vr:type = software.
+  The <id> is the foreign key that vr:software href values in other feeds point at. */ -}}
+{{- $page := .page -}}
+{{- $ext := $page.Params.external | default dict -}}
+  <entry>
+    <id>{{ $page.Permalink }}</id>
+    <title>{{ $page.Title }}</title>
+    <link rel="alternate" href="{{ $page.Permalink }}"/>
+    {{- with $page.Params.github }}
+    <link rel="related" href="https://github.com/{{ . }}"/>
+    {{- end }}
+    {{- with $page.Params.website }}
+    <link rel="related" href="{{ . }}"/>
+    {{- end }}
+    {{- $lastUpdated := "" -}}
+    {{- with $ext.last_updated }}{{ $lastUpdated = time . }}{{ end -}}
+    <updated>{{ partial "atom/updated.html" (dict "time" $lastUpdated "page" $page) | safeHTML }}</updated>
+    {{- with $page.Params.description }}
+    <summary>{{ . | strings.TrimSpace }}</summary>
+    {{- end }}
+    <vr:type>software</vr:type>
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "languages" "element" "language") -}}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "topics" "element" "topic") -}}
+    {{ partial "atom/linked.html" (dict "page" $page "taxonomy" "people" "element" "person") -}}
+    {{- with $page.Params.github }}
+    <vr:github>{{ . }}</vr:github>
+    {{- end }}
+    {{- with $page.Params.website }}
+    <vr:website>{{ . }}</vr:website>
+    {{- end }}
+    {{- with $page.Params.color }}
+    <vr:color>{{ . }}</vr:color>
+    {{- end }}
+    {{- with $ext.stars }}
+    <vr:stars>{{ . }}</vr:stars>
+    {{- end }}
+    {{- with $ext.forks }}
+    <vr:forks>{{ . }}</vr:forks>
+    {{- end }}
+    {{- with $ext.first_commit }}
+    <vr:first_commit>{{ (time .).Format "2006-01-02T15:04:05Z07:00" | safeHTML }}</vr:first_commit>
+    {{- end }}
+    {{- with $ext.latest_release }}
+    <vr:latest_release>{{ (time .).Format "2006-01-02T15:04:05Z07:00" | safeHTML }}</vr:latest_release>
+    {{- end }}
+    {{- with $ext.license }}
+    <vr:license>{{ . }}</vr:license>
+    {{- end }}
+    {{ partial "atom/image.html" (dict "page" $page) -}}
+    {{ partial "atom/body.html" (dict "page" $page) -}}
+  </entry>

--- a/layouts/partials/atom/feed.html
+++ b/layouts/partials/atom/feed.html
@@ -1,0 +1,28 @@
+{{- /*
+  atom/feed.html — Render a complete Atom feed <feed> wrapper around a
+  pre-sorted slice of pages, delegating each entry to a named section partial.
+
+  Input (dict):
+    "ctx"   — the section/taxonomy Page (used for feed id, title, self link)
+    "pages" — pre-sorted slice of pages to emit as entries
+    "title" — human-readable feed title
+    "entry" — name of the per-entry partial, e.g. "atom/entry-blog.html"
+*/ -}}
+{{- $ctx := .ctx -}}
+{{- $pages := .pages -}}
+{{- $title := .title -}}
+{{- $entry := .entry -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:vr="https://opensource.posit.co/ns/content">
+  <title>{{ $title }}</title>
+  <id>{{ $ctx.Permalink }}</id>
+  <link rel="alternate" href="{{ $ctx.Permalink }}"/>
+  {{- with $ctx.OutputFormats.Get "AtomContent" }}
+  <link rel="self" href="{{ .Permalink }}"/>
+  {{- end }}
+  <updated>{{ partial "atom/updated.html" (dict "page" $ctx) | safeHTML }}</updated>
+  <generator uri="https://gohugo.io">Hugo</generator>
+  {{- range $pages }}
+  {{ partial $entry (dict "page" .) }}
+  {{- end }}
+</feed>

--- a/layouts/partials/atom/feed.html
+++ b/layouts/partials/atom/feed.html
@@ -12,6 +12,18 @@
 {{- $pages := .pages -}}
 {{- $title := .title -}}
 {{- $entry := .entry -}}
+{{- /* Feed <updated> = newest timestamp across the context and all entries, so
+  pollers watching <feed><updated> never miss a changed entry. Consider each
+  page's .Lastmod and any external.last_updated (software), matching the value
+  the entry templates emit. */ -}}
+{{- $latest := $ctx.Lastmod -}}
+{{- range $pages -}}
+  {{- if gt .Lastmod.Unix $latest.Unix }}{{ $latest = .Lastmod }}{{ end -}}
+  {{- with (.Params.external | default dict).last_updated -}}
+    {{- $ext := time . -}}
+    {{- if gt $ext.Unix $latest.Unix }}{{ $latest = $ext }}{{ end -}}
+  {{- end -}}
+{{- end -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:vr="https://opensource.posit.co/ns/content">
   <title>{{ $title }}</title>
@@ -20,7 +32,14 @@
   {{- with $ctx.OutputFormats.Get "AtomContent" }}
   <link rel="self" href="{{ .Permalink }}"/>
   {{- end }}
-  <updated>{{ partial "atom/updated.html" (dict "page" $ctx) | safeHTML }}</updated>
+  <updated>{{ partial "atom/updated.html" (dict "time" $latest) | safeHTML }}</updated>
+  {{- /* Feed-level author. Atom requires an author at entry, source, or feed
+    scope; entries without their own <author> (people, software, resources)
+    inherit this one, while blog and event entries override it per item. */ -}}
+  <author>
+    <name>{{ site.Title }}</name>
+    <uri>{{ site.Home.Permalink }}</uri>
+  </author>
   <generator uri="https://gohugo.io">Hugo</generator>
   {{- range $pages }}
   {{ partial $entry (dict "page" .) }}

--- a/layouts/partials/atom/image.html
+++ b/layouts/partials/atom/image.html
@@ -1,0 +1,13 @@
+{{- /*
+  atom/image.html — Emit <vr:image href="ABSOLUTE_URL" alt="..."/> for a page,
+  using the site's get-image resolution. Absolute URL so it is usable directly
+  by consumers of the feed. Emits nothing when the page has no image.
+
+  Input (dict):
+    "page" — the Page object
+*/ -}}
+{{- $page := .page -}}
+{{- $result := partial "get-image.html" (dict "page" $page "fallback" true) -}}
+{{- with $result.image -}}
+      <vr:image href="{{ .Permalink }}"{{ with $result.alt }} alt="{{ . }}"{{ end }}/>
+{{ end -}}

--- a/layouts/partials/atom/linked.html
+++ b/layouts/partials/atom/linked.html
@@ -1,0 +1,20 @@
+{{- /*
+  atom/linked.html — Emit repeated <vr:ELEMENT term="..." href="..."/> elements
+  for a page's terms in a given taxonomy, carrying both the label and the
+  absolute URL so consumers can join items across feeds.
+
+  The element is built as a string and emitted with safeHTML: interpolating a
+  variable into an element-NAME position otherwise trips html/template's
+  contextual escaper (producing "ZgotmplZ").
+
+  Input (dict):
+    "page"     — the Page object
+    "taxonomy" — taxonomy name, e.g. "software", "languages", "topics"
+    "element"  — vr: local element name to emit, e.g. "software"
+*/ -}}
+{{- $page := .page -}}
+{{- $taxonomy := .taxonomy -}}
+{{- $element := .element -}}
+{{- range $page.GetTerms $taxonomy -}}
+      {{ printf "<vr:%s term=%q href=%q/>" $element .LinkTitle .Permalink | safeHTML }}
+{{ end -}}

--- a/layouts/partials/atom/updated.html
+++ b/layouts/partials/atom/updated.html
@@ -1,0 +1,27 @@
+{{- /*
+  atom/updated.html — Return a valid RFC3339 <updated> timestamp string.
+
+  Atom requires every entry (and the feed) to carry a non-empty, valid
+  atomDate. Some pages (e.g. people, undated software) have no date, so
+  .Lastmod is Go's zero time (0001-01-01). Fall back, in order, to an
+  explicit candidate time, then the page's Lastmod, then the build time.
+
+  Returns the formatted string (no element wrapper) — callers wrap it.
+
+  hugo.BuildDate is only populated in release binaries (via ldflags); in a
+  plain `hugo` build it is an empty string, so we use `now` as the final
+  fallback to guarantee a valid atomDate.
+
+  Input (dict):
+    "time" — optional preferred time.Time; pass "" or omit when absent
+    "page" — optional Page to read .Lastmod from; may be nil
+*/ -}}
+{{- $t := now -}}
+{{- with .page -}}
+  {{- if ge .Lastmod.Year 1970 }}{{ $t = .Lastmod }}{{ end -}}
+{{- end -}}
+{{- $cand := .time -}}
+{{- if and $cand (ne (printf "%T" $cand) "string") -}}
+  {{- if ge $cand.Year 1970 }}{{ $t = $cand }}{{ end -}}
+{{- end -}}
+{{- $t.UTC.Format "2006-01-02T15:04:05Z07:00" -}}

--- a/layouts/people/taxonomy.atomcontent.xml
+++ b/layouts/people/taxonomy.atomcontent.xml
@@ -1,0 +1,8 @@
+{{- /* Atom feed of all people profiles, alphabetical by name. */ -}}
+{{- $pages := (site.GetPage "/people").Pages.ByTitle -}}
+{{- partial "atom/feed.html" (dict
+  "ctx" .
+  "pages" $pages
+  "title" (printf "People on %s" .Site.Title)
+  "entry" "atom/entry-person.html"
+) -}}

--- a/layouts/resources/taxonomy.atomcontent.xml
+++ b/layouts/resources/taxonomy.atomcontent.xml
@@ -1,0 +1,13 @@
+{{- /* Atom feed of all resources (cheatsheets, videos, tutorials, webinars),
+  newest first. */ -}}
+{{- /* "resources" is both a section and a taxonomy, so RegularPagesRecursive is
+  unreliable here; enumerate the actual item pages the way the resource-type
+  itemindex templates do — .Pages that carry a resource_type. */ -}}
+{{- $pages := where (site.GetPage "/resources").Pages "Params.resource_type" "!=" nil -}}
+{{- $pages = $pages.ByDate.Reverse -}}
+{{- partial "atom/feed.html" (dict
+  "ctx" .
+  "pages" $pages
+  "title" (printf "Resources on %s" .Site.Title)
+  "entry" "atom/entry-resource.html"
+) -}}

--- a/layouts/software/taxonomy.atomcontent.xml
+++ b/layouts/software/taxonomy.atomcontent.xml
@@ -1,0 +1,8 @@
+{{- /* Atom feed of all software projects, alphabetical by title. */ -}}
+{{- $pages := (site.GetPage "/software").Pages.ByTitle -}}
+{{- partial "atom/feed.html" (dict
+  "ctx" .
+  "pages" $pages
+  "title" (printf "Software on %s" .Site.Title)
+  "entry" "atom/entry-software.html"
+) -}}


### PR DESCRIPTION
## Summary

Adds custom Atom feeds that expose rich, machine-readable metadata for the site's content, intended for downstream aggregation (e.g. velocirepo). Each section gets a feed at `<section>/index.md.xml`, kept distinct from the built-in RSS `index.xml` so both coexist.

Feeds are generated for **blog, events, people, software, and resources**, and include **every** item (no RSS limit).

## What each entry carries

- **Standard Atom fields**: `id`, `title`, links, `published`, `updated`, `summary`, `author`, `category`.
- **A `vr:`-namespaced metadata block** (`https://opensource.posit.co/ns/content`) with **absolute cross-link URLs**, so items can be joined across feeds — e.g. a blog post's `<vr:software term="pak" href=".../software/pak/"/>` points at that software's own entry `<id>`. Covers software, languages, topics, resources, image, and per-type fields (event dates/location, video stats, software stars/forks/license, person role/affiliation/social, etc.).
- **The raw Markdown body** in a standard `<content type="text/markdown">` element (not rendered HTML).

## Authors

Authors are derived from the natural source per type:
- **person** entries author themselves (title + own page URI)
- **software** and **resource** entries use their `people` field
- **blog** and **event** entries use `people` (as before)
- a **feed-level `<author>`** (the site) is the fallback for entries with no people listed, keeping every feed Atom-conformant

## Git-derived last-modified dates

Enables `enableGitInfo` so each entry's `<updated>` reflects the file's **last commit date** rather than the frontmatter publish date. This lets consumers detect when people, events, and resources are edited after publication, and gives dateless pages a stable timestamp instead of build time.

- `<published>` = frontmatter `date` (unchanged)
- `<updated>` = last commit that touched the file

This requires full git history at build time, so the production build checkout (`build-deploy.yml`) is switched to `fetch-depth: 0` — a shallow clone would stamp every page with the same commit date.

## Notes

- Purely additive: the built-in RSS feeds (`/blog/index.xml`, `/events/index.xml`) are unchanged.
- All five feeds validate as well-formed XML (`xmllint`).
- Sections/taxonomies that opt into the output format but have no dedicated feed (home, tags, `about/*`, `test-*`, blog sub-sections) emit empty, valid feeds via default guards.