### PR TITLE
Share blog authoring skills across agent harnesses

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/check-post/SKILL.md
+++ b/.claude/skills/check-post/SKILL.md
@@ -7,7 +7,7 @@ Run the blog post validation script and help the user fix any issues found.
 
 ## Step 1: Identify the post
 
-If the user provided a path via `$ARGUMENTS`, use that. Otherwise, look for blog posts changed on the current branch:
+If the user provided a path in their request, use that. Otherwise, look for blog posts changed on the current branch:
 
 ```sh
 git diff --name-only --diff-filter=d origin/main...HEAD -- 'content/blog/**/index.md' 'content/blog/**/index.qmd'

--- a/.claude/skills/check-post/SKILL.md
+++ b/.claude/skills/check-post/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: check-post
 description: Validate blog post frontmatter and placement
+argument-hint: "[post-path]"
 ---
 
 Run the blog post validation script and help the user fix any issues found.

--- a/.claude/skills/new-post/SKILL.md
+++ b/.claude/skills/new-post/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: new-post
 description: Scaffold a new blog post with inferred frontmatter, branch, and optional environment setup
+argument-hint: "[title] [topic] [authors] [format]"
 ---
 
 Help the user create a new blog post for the Posit open-source website. Work through these steps in order.

--- a/.claude/skills/new-post/SKILL.md
+++ b/.claude/skills/new-post/SKILL.md
@@ -21,7 +21,7 @@ Then ask whether they'd like to continue from the fork or stop to re-clone.
 
 ## Step 1: Gather information
 
-Ask the user for anything not already provided via arguments: `$ARGUMENTS`
+Ask the user for anything not already provided in their request:
 
 - **Title** — the post title
 - **Topic** — a brief description of what the post is about (use this to infer frontmatter)
@@ -116,6 +116,6 @@ Skip any of these if the author declines or already has a preview running.
 Finish with a short next-steps list:
 
 - Add `image` (1920×1080 PNG or JPG recommended) and `image-alt` to the frontmatter.
-- Once frontmatter is filled in, run `/check-post` to validate it.
-- Once the draft is ready, run `/review-post` for a content review before opening a PR.
+- Once frontmatter is filled in, use the `check-post` skill to validate it.
+- Once the draft is ready, use the `review-post` skill for a content review before opening a PR.
 - Open a PR against `main` to get a Netlify preview and a human review.

--- a/.claude/skills/review-post/SKILL.md
+++ b/.claude/skills/review-post/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: review-post
 description: Review a blog post's content against its frontmatter and the authoring guide
+argument-hint: "[post-path]"
 ---
 
 Review a blog post's content the way a reviewer would — checking that the content lines up with its frontmatter, surfacing things authors commonly miss, and flagging accessibility issues. Complements the `check-post` skill, which validates frontmatter mechanically; this skill reads the actual post text.

--- a/.claude/skills/review-post/SKILL.md
+++ b/.claude/skills/review-post/SKILL.md
@@ -3,13 +3,13 @@ name: review-post
 description: Review a blog post's content against its frontmatter and the authoring guide
 ---
 
-Review a blog post's content the way a reviewer would — checking that the content lines up with its frontmatter, surfacing things authors commonly miss, and flagging accessibility issues. Complements `/check-post`, which validates frontmatter mechanically; this skill reads the actual post text.
+Review a blog post's content the way a reviewer would — checking that the content lines up with its frontmatter, surfacing things authors commonly miss, and flagging accessibility issues. Complements the `check-post` skill, which validates frontmatter mechanically; this skill reads the actual post text.
 
 This skill **does not check writing style**. At the end, remind the author to get a human review for tone, clarity, and flow.
 
 ## Step 1: Identify the post
 
-If the user provided a path via `$ARGUMENTS`, use that. Otherwise, look for blog posts changed on the current branch:
+If the user provided a path in their request, use that. Otherwise, look for blog posts changed on the current branch:
 
 ```sh
 git diff --name-only --diff-filter=d origin/main...HEAD -- 'content/blog/**/index.md' 'content/blog/**/index.qmd'
@@ -25,7 +25,7 @@ For each post, read both the frontmatter and the body. If an `index.qmd` exists,
 
 Compare what the post actually says to what its frontmatter claims. Flag mismatches:
 
-- **`description` drift** — does the description still summarize the post accurately? Descriptions written at `/new-post` time often stop matching the finished draft.
+- **`description` drift** — does the description still summarize the post accurately? Descriptions written by the `new-post` skill often stop matching the finished draft.
 - **`software` / `languages` / `topics`** — do the values reflect what the post is actually about? If the post discusses ggplot2 but `software` only lists dplyr, flag it. If the inferred topics no longer fit, flag it. Suggest the values that *would* match.
 - **`source`** — if the post is clearly about one of the projects with a blog listing page (`positron`, `tidyverse`, `ai`, `shiny`, `great_tables`, `plotnine`, `pointblank`, `quarto`) and `source` isn't set, flag it. See `content/blog/_authoring-guide.md` for the rule.
 - **`title`** — does it match the post's actual focus, or has the angle shifted during writing?
@@ -70,9 +70,9 @@ Ask whether to apply the fixes. For accepted items:
 - If the post has an `index.qmd`, edit the `.qmd` (source of truth), then re-render to update `index.md`.
 - Otherwise, edit `index.md` directly.
 
-## Step 9: Re-run /check-post
+## Step 9: Re-run validation
 
-After any frontmatter edits, run `/check-post` (or the underlying script) on the post so the author sees a clean mechanical-validation pass before moving on.
+After any frontmatter edits, use the `check-post` skill (or the underlying script) on the post so the author sees a clean mechanical-validation pass before moving on.
 
 ## Step 10: Remind about human review
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ See [`content/blog/_authoring-guide.md`](content/blog/_authoring-guide.md) for f
 
 1. Clone this repository directly if you're an org member (you have Write access via the Everyone team, so branch PRs get auto-preview). Working from a fork is supported too — you'll just comment `/deploy-preview` on your PR to trigger a preview build.
 2. Open your agent in the project root
-3. Ask it to use the `new-post` skill — it will guide you through scaffolding, frontmatter, branch creation, and environment setup interactively
+3. Ask it to use the `new-post` skill (in Claude Code, just type `/new-post`) — it will guide you through scaffolding, frontmatter, branch creation, and environment setup interactively
 
 **Quick start without an Agent Skills client:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -382,13 +382,13 @@ external:
 
 See [`content/blog/_authoring-guide.md`](content/blog/_authoring-guide.md) for full guidance on post placement, format choice, setting up environments for executable posts, and how to preview your work.
 
-**Quick start with Claude Code:**
+**Quick start with an Agent Skills client:**
 
 1. Clone this repository directly if you're an org member (you have Write access via the Everyone team, so branch PRs get auto-preview). Working from a fork is supported too — you'll just comment `/deploy-preview` on your PR to trigger a preview build.
-2. Open Claude Code in the project root
-3. Run `/new-post` — it will guide you through scaffolding, frontmatter, branch creation, and environment setup interactively
+2. Open your agent in the project root
+3. Ask it to use the `new-post` skill — it will guide you through scaffolding, frontmatter, branch creation, and environment setup interactively
 
-**Quick start without Claude Code:**
+**Quick start without an Agent Skills client:**
 ```bash
 hugo new blog/my-post/index.md
 ```
@@ -405,7 +405,7 @@ uv run scripts/validate-blog-posts.py content/blog/my-post/index.md
 uv run scripts/validate-blog-posts.py --no-date-check
 ```
 
-If you're using Claude Code, the `/check-post` skill runs validation interactively and can offer fixes.
+If your agent supports Agent Skills, the `check-post` skill runs validation interactively and can offer fixes.
 
 ### Adding Team Members
 

--- a/content/blog/CLAUDE.md
+++ b/content/blog/CLAUDE.md
@@ -2,13 +2,13 @@
 
 For full authoring guidance — post placement, format choice, environments, previewing — see `_authoring-guide.md` in this directory.
 
-To create a new post, use the `/new-post` skill — it handles branch creation, scaffolding, frontmatter inference, and environment setup interactively. Only scaffold manually if the skill is unavailable.
+To create a new post, use the `new-post` skill — it handles branch creation, scaffolding, frontmatter inference, and environment setup interactively. Only scaffold manually if the skill is unavailable.
 
 For porting guidance, see `_porting-notes.md` (how to port) and `_editing-ported-posts.md` (working with ported posts).
 
 ## Validation
 
-Use the `/check-post` skill to validate a post's frontmatter interactively — it runs `scripts/validate-blog-posts.py`, reports issues, and can offer fixes. CI also runs this automatically on PRs that touch `content/blog/**`.
+Use the `check-post` skill to validate a post's frontmatter interactively — it runs `scripts/validate-blog-posts.py`, reports issues, and can offer fixes. CI also runs this automatically on PRs that touch `content/blog/**`.
 
 ## Required Metadata
 

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -6,7 +6,7 @@ All blog posts should be submitted as a pull request against `main` — don't pu
 
 If you already work from a fork (your own preference, or a personal-fork-first workflow), that's fine too — you'll just need to comment `/deploy-preview` on your PR once to trigger the preview build. Fork PRs can't auto-deploy because GitHub gives the workflow a read-only token with no access to our Netlify secrets.
 
-If you're using Claude Code, the `/new-post` skill will handle scaffolding, frontmatter, branch creation, and environment setup interactively.
+If your agent supports Agent Skills, ask it to use the `new-post` skill to handle scaffolding, frontmatter, branch creation, and environment setup interactively.
 
 ## Where to place your post
 
@@ -122,7 +122,7 @@ This runs Hugo and the Tailwind CSS watcher in parallel. The site will be availa
 
 Before opening a PR, give your draft a once-over for content issues that mechanical frontmatter validation can't catch.
 
-The `/review-post` skill reads the post body and flags:
+The `review-post` skill reads the post body and flags:
 
 - Content-vs-frontmatter drift (e.g. `description` no longer matching the finished draft, `software` / `languages` / `topics` out of date, missing `source`)
 - Placeholders left in the body (`TODO`, `TBD`, `[insert link]`, lorem ipsum)
@@ -130,7 +130,7 @@ The `/review-post` skill reads the post body and flags:
 - Code blocks missing a language tag
 - Body image alt text and heading hierarchy
 
-It re-runs `/check-post` at the end, so it covers frontmatter validation too.
+It uses the `check-post` skill at the end, so it covers frontmatter validation too.
 
 The skill **does not** check writing style, tone, or flow. Get a human reviewer for that as part of the PR — see [Publishing your post](#publishing-your-post) below.
 
@@ -196,9 +196,9 @@ Other flags:
 - `--strict` — treat warnings as errors
 - `--format markdown` — output markdown (used by CI for PR comments)
 
-### With Claude Code
+### With an Agent Skills client
 
-The `/check-post` skill runs validation interactively and can offer to fix issues it finds.
+The `check-post` skill runs validation interactively and can offer to fix issues it finds.
 
 ### When warnings are OK to ignore
 

--- a/content/blog/_authoring-guide.md
+++ b/content/blog/_authoring-guide.md
@@ -6,7 +6,7 @@ All blog posts should be submitted as a pull request against `main` — don't pu
 
 If you already work from a fork (your own preference, or a personal-fork-first workflow), that's fine too — you'll just need to comment `/deploy-preview` on your PR once to trigger the preview build. Fork PRs can't auto-deploy because GitHub gives the workflow a read-only token with no access to our Netlify secrets.
 
-If your agent supports Agent Skills, ask it to use the `new-post` skill to handle scaffolding, frontmatter, branch creation, and environment setup interactively.
+If your agent supports Agent Skills, ask it to use the `new-post` skill (in Claude Code, just type `/new-post`) to handle scaffolding, frontmatter, branch creation, and environment setup interactively.
 
 ## Where to place your post
 


### PR DESCRIPTION
## Summary

Convert the `new-post`, `check-post`, and `review-post` slash commands into [Agent Skills](https://agentskills.io/specification) and expose the same skills at `.agents/skills`. This keeps the existing Claude Code workflow while making the blog authoring tools available to other skill-aware agents.

## User-facing changes

- The three skills can be selected by the model when relevant—for example, `check-post` after frontmatter is edited.
- Claude Code users can still invoke `/new-post`, `/check-post`, and `/review-post` directly. Each skill now includes an argument hint for slash-command completion.
- The authoring docs describe the shared Agent Skills workflow and retain the direct Claude Code syntax where useful.

## Internal changes

- Move each command to `.claude/skills/<name>/SKILL.md`.
- Add `.agents/skills -> ../.claude/skills` so clients can share one copy of each skill.
- Replace `$ARGUMENTS` and slash-command references in skill bodies with client-neutral instructions.

## Compatibility

The Agent Skills implementation guide recommends [`.agents/skills` for cross-client interoperability](https://agentskills.io/client-implementation/adding-skills-support#where-to-scan). Clients that document this project-level path include [Codex](https://learn.chatgpt.com/docs/build-skills#where-to-save-skills), [GitHub Copilot](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills), [Cursor](https://cursor.com/docs/skills), [Gemini CLI](https://geminicli.com/docs/cli/skills/), [OpenCode](https://opencode.ai/docs/skills/), [Amp](https://ampcode.com/manual#agent-skills), and [Windsurf](https://docs.windsurf.com/windsurf/cascade/skills).

On Windows, cross-client discovery requires Git to materialize the symlink; with [`core.symlinks=false`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coresymlinks), Git checks it out as a plain file. Claude Code still reads the canonical `.claude/skills` directory.
