### PR TITLE
Add source: education to raw ported education posts

### DIFF
--- a/content/blog/ported/education/2019-08-26-learner-personas/index.markdown
+++ b/content/blog/ported/education/2019-08-26-learner-personas/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Siora Photography
 image: candle-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 ---
 

--- a/content/blog/ported/education/2019-09-16-community/index.markdown
+++ b/content/blog/ported/education/2019-09-16-community/index.markdown
@@ -19,6 +19,7 @@ photo:
   author: Shwetha Shankar
 image: flock-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ---

--- a/content/blog/ported/education/2019-09-24-welcome/index.markdown
+++ b/content/blog/ported/education/2019-09-24-welcome/index.markdown
@@ -12,6 +12,7 @@ photo:
   author: Desirée De Leon
 image: hello-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 tags:

--- a/content/blog/ported/education/2019-09-25-upcoming-instructor-training-events/index.markdown
+++ b/content/blog/ported/education/2019-09-25-upcoming-instructor-training-events/index.markdown
@@ -19,6 +19,7 @@ photo:
   author: Ricky Kharawala
 image: train-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2019-09-26-remaster-tidyverse/index.markdown
+++ b/content/blog/ported/education/2019-09-26-remaster-tidyverse/index.markdown
@@ -13,6 +13,7 @@ photo:
   author: Patrick Hendry
 image: telescope-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["tidyverse"]
 languages: ["R"]

--- a/content/blog/ported/education/2019-10-15-a-summer-of-rstudio-and-ggplot2/index.markdown
+++ b/content/blog/ported/education/2019-10-15-a-summer-of-rstudio-and-ggplot2/index.markdown
@@ -16,6 +16,7 @@ tags:
   - Education
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["ggplot2"]
 languages: ["R"]

--- a/content/blog/ported/education/2019-10-18-tools-for-teaching-yaml-with-ymlthis/index.markdown
+++ b/content/blog/ported/education/2019-10-18-tools-for-teaching-yaml-with-ymlthis/index.markdown
@@ -20,6 +20,7 @@ tags:
   - Teaching
 image: stones-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["ymlthis"]
 languages: ["R"]

--- a/content/blog/ported/education/2019-10-21-my-javascript-internship-at-rstudio/index.markdown
+++ b/content/blog/ported/education/2019-10-21-my-javascript-internship-at-rstudio/index.markdown
@@ -16,6 +16,7 @@ tags:
   - Education
 image: java-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 categories:
   - Community

--- a/content/blog/ported/education/2019-10-23-12-weeks-at-rstudio/index.markdown
+++ b/content/blog/ported/education/2019-10-23-12-weeks-at-rstudio/index.markdown
@@ -16,6 +16,7 @@ tags:
   - Education
 image: colors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 categories:

--- a/content/blog/ported/education/2019-10-25-what-it-was-like-interning-for-rstudio/index.markdown
+++ b/content/blog/ported/education/2019-10-25-what-it-was-like-interning-for-rstudio/index.markdown
@@ -15,6 +15,7 @@ tags:
   - Education
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 categories:

--- a/content/blog/ported/education/2019-10-28-workshops-conf/index.markdown
+++ b/content/blog/ported/education/2019-10-28-workshops-conf/index.markdown
@@ -18,6 +18,7 @@ photo:
   author: Pedro Lastra
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2019-11-07-first-software-engineering-internship/index.markdown
+++ b/content/blog/ported/education/2019-11-07-first-software-engineering-internship/index.markdown
@@ -17,6 +17,7 @@ tags:
   - Education
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 categories:

--- a/content/blog/ported/education/2019-11-20-my-experience-with-rstudio-instructor-training/index.markdown
+++ b/content/blog/ported/education/2019-11-20-my-experience-with-rstudio-instructor-training/index.markdown
@@ -17,6 +17,7 @@ tags:
   - Certify
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2019-11-25-rstudio-internships-2020-preview/index.markdown
+++ b/content/blog/ported/education/2019-11-25-rstudio-internships-2020-preview/index.markdown
@@ -15,6 +15,7 @@ photo:
   author: Denny Luan
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 categories:

--- a/content/blog/ported/education/2019-12-02-this-is-not-like-the-others/index.markdown
+++ b/content/blog/ported/education/2019-12-02-this-is-not-like-the-others/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Matt Nelson
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 categories:
   - Community

--- a/content/blog/ported/education/2019-12-09-10-quick-tips-for-making-your-stuff-findable/index.markdown
+++ b/content/blog/ported/education/2019-12-09-10-quick-tips-for-making-your-stuff-findable/index.markdown
@@ -11,6 +11,7 @@ photo:
   author: Drew Beamer
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 categories:
   - Best Practices

--- a/content/blog/ported/education/2019-12-23-r-for-software-engineers/index.markdown
+++ b/content/blog/ported/education/2019-12-23-r-for-software-engineers/index.markdown
@@ -14,6 +14,7 @@ photo:
   author: Mega Caesaria
 image: r4se-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-02-01-gestalt-internship/index.markdown
+++ b/content/blog/ported/education/2020-02-01-gestalt-internship/index.markdown
@@ -19,6 +19,7 @@ description: |
   And what you get out of it is more than technical training.
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ---

--- a/content/blog/ported/education/2020-02-05-instructor-certification-exams/index.markdown
+++ b/content/blog/ported/education/2020-02-05-instructor-certification-exams/index.markdown
@@ -18,6 +18,7 @@ photo:
   author: Angelina Litvin
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-02-13-conf20-tidytext/index.markdown
+++ b/content/blog/ported/education/2020-02-13-conf20-tidytext/index.markdown
@@ -20,6 +20,7 @@ photo:
   author: Eli Francis
 image: books-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-02-13-conf20-ts/index.markdown
+++ b/content/blog/ported/education/2020-02-13-conf20-ts/index.markdown
@@ -19,6 +19,7 @@ photo:
   author: Alessandro Venturi
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-02-13-conf20-wtf/index.markdown
+++ b/content/blog/ported/education/2020-02-13-conf20-wtf/index.markdown
@@ -19,6 +19,7 @@ photo:
 description: Highlights from the What They Forgot to Teach You About R workshop.
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-02-13-conf2020-workshops/index.markdown
+++ b/content/blog/ported/education/2020-02-13-conf2020-workshops/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Susie Ho
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-02-14-conf20-intro-ml/index.markdown
+++ b/content/blog/ported/education/2020-02-14-conf20-intro-ml/index.markdown
@@ -18,6 +18,7 @@ description: Here is your roadmap to our two-day rstudio::conf(2020) introductor
   workshop on machine learning with the tidyverse and tidymodels.
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["tidymodels"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-02-18-conf20-dataviz/index.markdown
+++ b/content/blog/ported/education/2020-02-18-conf20-dataviz/index.markdown
@@ -20,6 +20,7 @@ photo:
   author: Markus Spiske
 image: art-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["ggplot2"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-02-18-conf20-r-excel/index.markdown
+++ b/content/blog/ported/education/2020-02-18-conf20-r-excel/index.markdown
@@ -22,6 +22,7 @@ description: |
   Our 2-day intro to becoming a modern R user-full of tidyverse, RMarkdown, GitHub, collaboration & reproducibility.
 image: r-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-02-18-conf20-tidy-tools/index.markdown
+++ b/content/blog/ported/education/2020-02-18-conf20-tidy-tools/index.markdown
@@ -20,6 +20,7 @@ photo:
   author: Lachlan Donald
 image: building-tidy-tools-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-02-24-applications-for-2020-intern-program-are-now-open/index.markdown
+++ b/content/blog/ported/education/2020-02-24-applications-for-2020-intern-program-are-now-open/index.markdown
@@ -14,6 +14,7 @@ description: |
   Want to apply to this year's summer intern program? Here's how.
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 categories:

--- a/content/blog/ported/education/2020-03-06-r-bootcamp/index.markdown
+++ b/content/blog/ported/education/2020-03-06-r-bootcamp/index.markdown
@@ -24,6 +24,7 @@ photo:
   author: John Schnobrich
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-03-17-teaching-online-on-short-notice/index.markdown
+++ b/content/blog/ported/education/2020-03-17-teaching-online-on-short-notice/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Hello I'm Nik
 image: teaching-online-on-short-notice-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 ported_categories:
   - teach

--- a/content/blog/ported/education/2020-03-19-resources-tips-for-teaching-with-R-remotely/index.markdown
+++ b/content/blog/ported/education/2020-03-19-resources-tips-for-teaching-with-R-remotely/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Maya Maceka
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-03-23-online-teaching-qa/index.markdown
+++ b/content/blog/ported/education/2020-03-23-online-teaching-qa/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Wonderlane
 image: online-teaching-qa-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 ported_categories:
   - teach

--- a/content/blog/ported/education/2020-03-24-reopening-training-applications/index.markdown
+++ b/content/blog/ported/education/2020-03-24-reopening-training-applications/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Debby Hudson
 image: reopening-training-applications-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-03-27-cheatsheet-tips/index.markdown
+++ b/content/blog/ported/education/2020-03-27-cheatsheet-tips/index.markdown
@@ -11,6 +11,7 @@ photo:
 description: Tips for making a new cheatsheet
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["cheatsheets"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-03-31-march-2020-instructors/index.markdown
+++ b/content/blog/ported/education/2020-03-31-march-2020-instructors/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Robert Zunikoff
 image: march-2020-instructors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-04-01-teaching-with-rstudio-cloud-q-a/index.markdown
+++ b/content/blog/ported/education/2020-04-01-teaching-with-rstudio-cloud-q-a/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Alex Machado
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-04-06-first-year-of-instructor-training/index.markdown
+++ b/content/blog/ported/education/2020-04-06-first-year-of-instructor-training/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Alev Takil
 image: first-year-of-instructor-training-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-04-06-sharing-short-notice/index.markdown
+++ b/content/blog/ported/education/2020-04-06-sharing-short-notice/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Raw Pixel
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 ported_categories:
   - teach

--- a/content/blog/ported/education/2020-04-08-announcing-2020-interns/index.markdown
+++ b/content/blog/ported/education/2020-04-08-announcing-2020-interns/index.markdown
@@ -13,6 +13,7 @@ description: |
   Meet this year's interns.
 image: feature-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 categories:

--- a/content/blog/ported/education/2020-04-30-april-2020-instructors/index.markdown
+++ b/content/blog/ported/education/2020-04-30-april-2020-instructors/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Robert Zunikoff
 image: april-2020-instructors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-05-04-flair/index.markdown
+++ b/content/blog/ported/education/2020-05-04-flair/index.markdown
@@ -18,6 +18,7 @@ photo:
   author: Christina Hernández
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["rmarkdown"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-05-19-learnr/index.markdown
+++ b/content/blog/ported/education/2020-05-19-learnr/index.markdown
@@ -18,6 +18,7 @@ photo:
   author: Allison Horst
 image: flying-na-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["learnr", "rmarkdown"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-05-19-remote-roundup/index.markdown
+++ b/content/blog/ported/education/2020-05-19-remote-roundup/index.markdown
@@ -18,6 +18,7 @@ photo:
   author: Manuel Peris Tirado
 image: remote-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 ported_categories:
   - learn

--- a/content/blog/ported/education/2020-05-25-thinkr-shiny-training/index.markdown
+++ b/content/blog/ported/education/2020-05-25-thinkr-shiny-training/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Noel Broda
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["shiny-r"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-05-26-teach-interactive-course/index.markdown
+++ b/content/blog/ported/education/2020-05-26-teach-interactive-course/index.markdown
@@ -20,6 +20,7 @@ photo:
   author: Alain Pham
 image: thumbnail-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["learnr"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-05-28-deep-learning-workshop-at-rstudio-conf-2020/index.markdown
+++ b/content/blog/ported/education/2020-05-28-deep-learning-workshop-at-rstudio-conf-2020/index.markdown
@@ -20,6 +20,7 @@ photo:
   author: Pietro Jeng
 image: conf20-dl-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["keras3", "tensorflow"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-06-01-lucerne-workshops/index.markdown
+++ b/content/blog/ported/education/2020-06-01-lucerne-workshops/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Aswathy N
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["shiny-r"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-06-01-may-2020-instructors/index.markdown
+++ b/content/blog/ported/education/2020-06-01-may-2020-instructors/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Robert Zunikoff
 image: may-2020-instructors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-06-08-conf20-org-first-pkg/index.markdown
+++ b/content/blog/ported/education/2020-06-08-conf20-org-first-pkg/index.markdown
@@ -22,6 +22,7 @@ photo:
   author: Leone Venter
 image: pkg-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["devtools", "usethis"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-06-22-native-classroom/index.markdown
+++ b/content/blog/ported/education/2020-06-22-native-classroom/index.markdown
@@ -15,6 +15,7 @@ photo:
   author: Graeme Nicholl
 image: native-classroom-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["ggplot2"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-06-24-summer-camp-for-high-schoolers/index.markdown
+++ b/content/blog/ported/education/2020-06-24-summer-camp-for-high-schoolers/index.markdown
@@ -14,6 +14,7 @@ photo:
   author: Ryan Cooley
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["learnr"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-06-29-working-with-spreadsheets/index.markdown
+++ b/content/blog/ported/education/2020-06-29-working-with-spreadsheets/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Lukas Blazek
 image: working-with-spreadsheets-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["readxl"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-06-30-june-2020-instructors/index.markdown
+++ b/content/blog/ported/education/2020-06-30-june-2020-instructors/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Robert Zunikoff
 image: june-2020-instructors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-06-30-tidymodels-internship/index.markdown
+++ b/content/blog/ported/education/2020-06-30-tidymodels-internship/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Sara Codair
 image: tidymodels-internship-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["tidymodels"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-07-02-a11y-midterm/index.markdown
+++ b/content/blog/ported/education/2020-07-02-a11y-midterm/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Elia Pellegrini
 image: a11y-midterm-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 categories:
   - Community

--- a/content/blog/ported/education/2020-07-06-instructor-certification-findings/index.markdown
+++ b/content/blog/ported/education/2020-07-06-instructor-certification-findings/index.markdown
@@ -15,6 +15,7 @@ photo:
   author: Greg Wilson
 image: instructor-certification-findings-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-07-13-teaching-the-tidyverse-in-2020-part-1-getting-started/index.markdown
+++ b/content/blog/ported/education/2020-07-13-teaching-the-tidyverse-in-2020-part-1-getting-started/index.markdown
@@ -15,6 +15,7 @@ photo:
   url: https://unsplash.com/photos/oMpAz-DN-9I
   author: Greg Rakozy
 ported_from: education
+source: education
 port_status: in-progress
 software: ["tidyverse"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-07-14-cloud-update/index.markdown
+++ b/content/blog/ported/education/2020-07-14-cloud-update/index.markdown
@@ -20,6 +20,7 @@ photo:
   author: Nacho Rochon
 image: clouds-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-07-15-teaching-the-tidyverse-in-2020-part-2-data-visualisation/index.markdown
+++ b/content/blog/ported/education/2020-07-15-teaching-the-tidyverse-in-2020-part-2-data-visualisation/index.markdown
@@ -18,6 +18,7 @@ editor_options:
   markdown:
     canonical: yes
 ported_from: education
+source: education
 port_status: in-progress
 software: ["tidyverse"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-07-17-teaching-the-tidyverse-in-2020-part-3-data-wrangling-and-tidying/index.markdown
+++ b/content/blog/ported/education/2020-07-17-teaching-the-tidyverse-in-2020-part-3-data-wrangling-and-tidying/index.markdown
@@ -15,6 +15,7 @@ photo:
   url: https://unsplash.com/photos/wEL2zPX3jDg
   author: Fabio Ballasina
 ported_from: education
+source: education
 port_status: in-progress
 software: ["tidyverse"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-07-19-teaching-the-tidyverse-in-2020-part-4-when-to-purrr/index.markdown
+++ b/content/blog/ported/education/2020-07-19-teaching-the-tidyverse-in-2020-part-4-when-to-purrr/index.markdown
@@ -15,6 +15,7 @@ photo:
   url: https://unsplash.com/photos/wEL2zPX3jDg
   author: Fabio Ballasina
 ported_from: education
+source: education
 port_status: in-progress
 software: ["tidyverse"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-07-20-gtsummary/index.markdown
+++ b/content/blog/ported/education/2020-07-20-gtsummary/index.markdown
@@ -23,6 +23,7 @@ photo:
   author: Daniel von Appen
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["rmarkdown"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-07-27-penguins-cran/index.markdown
+++ b/content/blog/ported/education/2020-07-27-penguins-cran/index.markdown
@@ -19,6 +19,7 @@ photo:
   author: Kristen Gorman
 image: featured-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-07-28-announcing-glosario/index.markdown
+++ b/content/blog/ported/education/2020-07-28-announcing-glosario/index.markdown
@@ -26,6 +26,7 @@ photo:
   author: Joshua Hoehne
 image: announcing-glosario-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 ported_categories:
   - learn

--- a/content/blog/ported/education/2020-08-03-hippocratic-license/index.markdown
+++ b/content/blog/ported/education/2020-08-03-hippocratic-license/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Daniele D'Andreti
 image: hippocratic-license-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 ported_categories:
   - teach

--- a/content/blog/ported/education/2020-08-05-july-2020-instructors/index.markdown
+++ b/content/blog/ported/education/2020-08-05-july-2020-instructors/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Robert Zunikoff
 image: july-2020-instructors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-08-17-spreadsheet-workflows-using-r/index.markdown
+++ b/content/blog/ported/education/2020-08-17-spreadsheet-workflows-using-r/index.markdown
@@ -17,6 +17,7 @@ photo:
   author: Mika Baumeister
 image: spreadsheet-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["tidyverse"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-08-18-more-sample-exams/index.markdown
+++ b/content/blog/ported/education/2020-08-18-more-sample-exams/index.markdown
@@ -15,6 +15,7 @@ photo:
   author: Greg Wilson
 image: more-sample-exams-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-08-31-august-2020-instructors/index.markdown
+++ b/content/blog/ported/education/2020-08-31-august-2020-instructors/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Robert Zunikoff
 image: august-2020-instructors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-09-10-shiny-solutions/index.markdown
+++ b/content/blog/ported/education/2020-09-10-shiny-solutions/index.markdown
@@ -22,6 +22,7 @@ photo:
   author: Paul Gaudriault
 image: shiny-solutions-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["shiny-r"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-09-11-concept-maps/index.markdown
+++ b/content/blog/ported/education/2020-09-11-concept-maps/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Taylor Vick
 image: concept-maps-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["concept-maps"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-09-17-delivering-learnr-tutorials-in-a-package/index.markdown
+++ b/content/blog/ported/education/2020-09-17-delivering-learnr-tutorials-in-a-package/index.markdown
@@ -15,6 +15,7 @@ photo:
   author: Erda Estremera
 image: dog-in-box-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["rmarkdown", "learnr"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-09-21-data-latam/index.markdown
+++ b/content/blog/ported/education/2020-09-21-data-latam/index.markdown
@@ -18,6 +18,7 @@ photo:
   url: https://unsplash.com/photos/fpvUvv-VEuA
 image: data-latam-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-09-30-september-2020-instructors/index.markdown
+++ b/content/blog/ported/education/2020-09-30-september-2020-instructors/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Robert Zunikoff
 image: september-2020-instructors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-10-02-example-shiny-exam/index.markdown
+++ b/content/blog/ported/education/2020-10-02-example-shiny-exam/index.markdown
@@ -15,6 +15,7 @@ photo:
   author: Greg Wilson
 image: example-shiny-exam-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["shiny-r"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-10-05-ds-in-edu/index.markdown
+++ b/content/blog/ported/education/2020-10-05-ds-in-edu/index.markdown
@@ -21,6 +21,7 @@ editor_options:
     wrap: 72
 image: banner-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 software: ["bookdown"]
 languages: ["R"]

--- a/content/blog/ported/education/2020-10-05-glosario-sprint/index.markdown
+++ b/content/blog/ported/education/2020-10-05-glosario-sprint/index.markdown
@@ -18,6 +18,7 @@ photo:
   author: Joshua Hoehne
 image: glosario-sprint-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 ported_categories:
   - learn

--- a/content/blog/ported/education/2020-10-07-learner-personas/index.markdown
+++ b/content/blog/ported/education/2020-10-07-learner-personas/index.markdown
@@ -14,6 +14,7 @@ photo:
   author: Siora Photography
 image: learner-personas-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 ported_categories:
   - teach

--- a/content/blog/ported/education/2020-10-30-october-2020-instructors/index.markdown
+++ b/content/blog/ported/education/2020-10-30-october-2020-instructors/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Robert Zunikoff
 image: october-2020-instructors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-11-16-BlackInDataWeek/index.markdown
+++ b/content/blog/ported/education/2020-11-16-BlackInDataWeek/index.markdown
@@ -14,6 +14,7 @@ photo:
   url: https://unsplash.com/photos/AHBNGvRTm_A
 image: data-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-12-03-november-2020-instructors/index.markdown
+++ b/content/blog/ported/education/2020-12-03-november-2020-instructors/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Robert Zunikoff
 image: november-2020-instructors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-12-07-carpentries-support/index.markdown
+++ b/content/blog/ported/education/2020-12-07-carpentries-support/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Hunter Haley
 image: carpentries-support-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-12-18-metadocencia/index.markdown
+++ b/content/blog/ported/education/2020-12-18-metadocencia/index.markdown
@@ -16,6 +16,7 @@ photo:
   url: https://unsplash.com/photos/OyCl7Y4y0Bk
 image: apple-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2020-12-22-december-2020-instructors/index.markdown
+++ b/content/blog/ported/education/2020-12-22-december-2020-instructors/index.markdown
@@ -16,6 +16,7 @@ photo:
   author: Robert Zunikoff
 image: december-2020-instructors-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:

--- a/content/blog/ported/education/2021-01-28-aaron-durham-mentorship-wrapup/index.markdown
+++ b/content/blog/ported/education/2021-01-28-aaron-durham-mentorship-wrapup/index.markdown
@@ -15,6 +15,7 @@ photo:
   url: https://unsplash.com/photos/4Zk45jNyQS4
 image: aaron-durham-mentorship-wrapup-wd.jpg
 ported_from: education
+source: education
 port_status: in-progress
 languages: ["R"]
 ported_categories:


### PR DESCRIPTION
The 85 raw `.markdown` education posts have `ported_from: education` but were missing `source: education` — an oversight from the bulk education port. They're published at their own URLs but invisible on the [education project blog listing](https://opensource.posit.co/blog/q/education/), which currently shows only the 5 fully-ported posts.

This adds `source: education` to each (single line inserted after `ported_from`), bringing the listing to all 87 published education posts. Verified locally with a full Hugo build.

Prerequisite context: we're about to file a redirect issue on [rstudio/education.rstudio.com](https://github.com/rstudio/education.rstudio.com) pointing 88 legacy URLs at these posts, so the listing should reflect them.