### PR TITLE
Add canonical URL support for posts that also live on posit.co/blog

### DIFF
--- a/content/blog/CLAUDE.md
+++ b/content/blog/CLAUDE.md
@@ -62,6 +62,7 @@ Freeform. Avoid duplicating `software` or `topics` values.
 | `nohero` | Boolean, hides the hero image |
 | `hidesubscription` | Boolean, hides the subscription CTA |
 | `photo.url` / `photo.author` | Stock photo attribution |
+| `canonical_url` | Set only when another site's copy is the canonical version (e.g. the same post on `posit.co/blog`); the `<link rel="canonical">` tag and JSON-LD then point there. Omit for the default: our page is canonical (self-referencing tag). |
 | `code-line-numbers` | Boolean, turns on line-number gutters for every code block on the page |
 
 ## Project Blog Listing

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,6 +9,9 @@
   content="{{ with .Params.Keywords }}{{ delimit . ", " }}{{ else }}{{ $.Site.Params.Keywords }}{{ end }}"
 />
 <meta name="robots" content="noodp" />
+{{- /* Pages default to self-canonical; canonical_url in frontmatter defers to
+     another site's copy (e.g. posit.co/blog) */ -}}
+<link rel="canonical" href="{{ or .Params.canonical_url .Permalink }}" />
 {{- if $.Site.Params.pwa.enabled }}<link rel="manifest" href="/manifest.json" />{{ end -}}
 
 {{- /* Custom Open Graph and Twitter images for blog posts */ -}}

--- a/layouts/partials/jsonld.html
+++ b/layouts/partials/jsonld.html
@@ -27,12 +27,13 @@
   -}}
 
 {{- else if and (eq .Section "blog") .IsPage -}}
+  {{- $canonical := or .Params.canonical_url .Permalink -}}
   {{- $ld = dict
         "@context" "https://schema.org"
         "@type" "BlogPosting"
         "headline" .Title
-        "url" .Permalink
-        "mainEntityOfPage" (dict "@type" "WebPage" "@id" .Permalink)
+        "url" $canonical
+        "mainEntityOfPage" (dict "@type" "WebPage" "@id" $canonical)
         "datePublished" (.Date.Format "2006-01-02T15:04:05-07:00")
         "dateModified" (.Lastmod.Format "2006-01-02T15:04:05-07:00")
         "publisher" $org


### PR DESCRIPTION
## What this does

Some of our blog posts are published in two places: here on the open source site and on posit.co/blog. When the same article exists at two URLs, search engines like Google have to guess which one is the "real" version — and they may split ranking credit between the two copies, or show the wrong one in search results.

The fix is a standard web mechanism called a **canonical URL**: an invisible tag in the page's code that tells search engines "this is the official home of this content — send all the search credit there." Readers never see it; only search engine crawlers do.

## How it works now

- **By default, every page on this site declares itself as the official version.** No action needed from post authors — this happens automatically.
- **When posit.co's copy should be the official version**, the post author adds one line to the post's metadata:

  ```yaml
  canonical_url: https://posit.co/blog/name-of-the-post/
  ```

  The page then tells search engines to treat the posit.co version as the real one, and our copy stops competing with it in search results. The post itself still displays normally on our site for anyone who visits.

## What changed technically

- `layouts/partials/head.html` — every page now emits a `<link rel="canonical">` tag (self-referencing by default, or pointing at `canonical_url` when set). The site previously emitted no canonical tags at all.
- `layouts/partials/jsonld.html` — the structured data we provide to search engines for blog posts now uses the same canonical URL, so both signals agree.
- `content/blog/CLAUDE.md` — the new field is documented in the blog metadata reference.

## One limitation to know about

This only covers the case where **posit.co's copy is the official one**. For the reverse — where **our** copy should be official — the tag has to be added on posit.co's side, which is outside this repo. That needs coordination with whoever manages posit.co.

## How it was tested

Ran a full production build: a post with `canonical_url` set correctly pointed its canonical tag and structured data at the posit.co URL, and posts without it correctly pointed at themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


------------------

## What post goes where?

Most of the historical posts @cwickham brought over to the open source blog are strictly open source themed.  Claude found a couple that should probably point to posit.co as the canonical link:

> I scanned all 999 posts three ways: paid-product terms in title/description/software fields, mention density in body text, and a loose title sweep (which mostly caught false positives like "Databricks Connect" and "joining the ggplot2 team"). Then I checked which candidates actually exist on posit.co/blog, since canonical_url has to point at a real page.

> Recommend adding canonical_url (verified live on posit.co):

> 1. Post: Shiny Server (Pro) 1.4.6
https://opensource.posit.co/blog/2016-09-22_shiny-server-1-4-6/
https://posit.co/blog/shiny-server-1-4-6

> 2. Post: Integrating Dynamic R and Python Models in Tableau Using plumbertableau
https://opensource.posit.co/blog/2021-12-20_dynamic-r-and-python-models-in-tableau-using-plumbertableau/
https://posit.co/blog/dynamic-r-and-python-models-in-tableau-using-plumbertableau

> Both are judgment calls worth a sanity check from you: the Shiny Server post covers the open-source server and Pro, but its substance is Pro security fixes. The plumbertableau post is about an open-source package, but the entire workflow it describes runs on RStudio Connect (mentioned 10 times).

> Fit the "paid product" rule but have no posit.co/blog copy to point at:

> 3. Post: Teaching online with RStudio Cloud
https://opensource.posit.co/blog/2020-04-01_teaching-with-rstudio-cloud-q-a/
https://education.rstudio.com/blog/2020/04/teaching-with-rstudio-cloud-q-a/

> 4. Post: Upcoming changes to RStudio Cloud pricing
https://opensource.posit.co/blog/2020-07-14_cloud-plans/
https://education.rstudio.com/blog/2020/07/cloud-plans/

> Everything else that mentioned Connect/Workbench/Cloud (pins, blastula, mirai, mcptools, Quarto 1.9, Positron releases, bslib, reprex, etc.) is clearly about open-source software with the paid product as a passing deployment mention — those stay ours.
