### PR TITLE
Fix broken blog link and photo filenames on useR! 2026 page

### DIFF
--- a/content/events/user-2026/_index.md
+++ b/content/events/user-2026/_index.md
@@ -45,14 +45,14 @@ Together, Posit Assistant and mcp-repl illustrate two ways to bring R’s intera
 We had an incredible time exploring Warsaw and chatting all things R!  Charlie had such a great time that he wrote a blog post on the experience:
 
 {{< insert-items format="card" hide-badge=true >}}
-- blog/2026-07-14_user-2026-warsaw/
+- blog/user-2026-warsaw/
 {{< /insert-items>}}
 
 {{< gallery title="Photos from the event" >}}
-- file: photos/user1.jpg
+- file: photos/user1.jpeg
   caption: "Opening reception"
-- file: photos/user2.jpg
+- file: photos/user2.jpeg
   caption: "Charlie's presentation"
-- file: photos/scipy3.jpeg
+- file: photos/user3.jpeg
   caption: "Group photo"
 {{< /gallery >}}


### PR DESCRIPTION
### Prerequisite check

- [ ] **I have linked an approved GitHub Issue below.** (Required for all changes except minor typos/broken links).

### Related Issue

No issue — this fixes broken links/filenames that were surfacing as build warnings.

### Description of changes

The `insert-items` slug on the useR! 2026 event page pointed at `blog/2026-07-14_user-2026-warsaw/`, but the post lives at `content/blog/user-2026-warsaw/`, so the `site.GetPage` lookup in `layouts/partials/item.html` failed and the blog card silently vanished from the page. The gallery also referenced `.jpg` for three photos that are `.jpeg` on disk, one of which was still a leftover `scipy3.jpeg` from a different event. Together these produced four `WARN` lines in the `build-and-deploy` job.

### Screenshots or previews (if applicable)

Verified against a local build using the version of Hugo that CI pins (extended 0.158.0, `--buildFuture`): the build is now warning-free, and `public/events/user-2026/index.html` contains the `user-2026-warsaw` card link plus all three gallery images and their Hugo-processed variants. See the deploy preview for the rendered page.

### Checklist

- [x] My code/content builds locally without errors or warnings.
- [x] I have verified that all links and code blocks function properly.
- [x] This contribution aligns with the project's `CONTRIBUTING.md` guidelines.