### PR TITLE
Fail the build on Hugo warnings and a degraded search index

### DIFF
--- a/.github/hugo-warning-allowlist.txt
+++ b/.github/hugo-warning-allowlist.txt
@@ -1,0 +1,7 @@
+# Hugo warnings that are known and accepted, one fixed-string substring per line.
+# A line matches if it appears anywhere in the WARN/ERROR line.
+#
+# Every entry needs a comment saying why it can't be fixed and, ideally, a link.
+# Delete entries as they get fixed — this list should only shrink.
+#
+# Blank lines and lines starting with # are ignored.

--- a/.github/scripts/assert-no-hugo-warnings.sh
+++ b/.github/scripts/assert-no-hugo-warnings.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Fail if a Hugo build log contains WARN/ERROR lines that aren't allowlisted.
+#
+# Usage: assert-no-hugo-warnings.sh <hugo-build.log>
+set -euo pipefail
+
+log="${1:?usage: $0 <hugo-build.log>}"
+allowlist="$(dirname "$0")/../hugo-warning-allowlist.txt"
+
+if [ ! -f "$log" ]; then
+    echo "::error::Build log not found: $log"
+    exit 1
+fi
+
+# Hugo prefixes diagnostics with "WARN" / "ERROR". Strip the log level and any
+# leading whitespace so allowlist entries can be written as the bare message.
+warnings="$(grep -E '^(WARN|ERROR)' "$log" || true)"
+
+if [ -z "$warnings" ]; then
+    echo "No Hugo warnings or errors."
+    exit 0
+fi
+
+# Drop comments and blank lines from the allowlist. A blank line would be a
+# fixed-string pattern matching every line, silently suppressing everything.
+patterns="$(mktemp)"
+trap 'rm -f "$patterns"' EXIT
+if [ -f "$allowlist" ]; then
+    grep -vE '^[[:space:]]*(#|$)' "$allowlist" > "$patterns" || true
+fi
+
+unexpected="$(printf '%s\n' "$warnings" | grep -vFf "$patterns" || true)"
+
+if [ -n "$unexpected" ]; then
+    count="$(printf '%s\n' "$unexpected" | wc -l | tr -d ' ')"
+    printf '%s\n' "$unexpected"
+    echo "::error::Hugo emitted $count unexpected warning/error line(s); see above."
+    echo "Fix them, or add the message to $(basename "$allowlist") with a comment explaining why."
+    exit 1
+fi
+
+echo "All Hugo warnings are allowlisted."

--- a/.github/scripts/assert-search-index.sh
+++ b/.github/scripts/assert-search-index.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Fail if Pagefind indexed suspiciously few pages.
+#
+# Pagefind only exits non-zero when it finds nothing at all. A partial index --
+# Hugo emitting a fraction of the site, or a layout change dropping the
+# data-pagefind-body markers -- exits 0 and silently ships broken search, so the
+# page count is the signal worth checking.
+set -euo pipefail
+
+entry="public/pagefind/pagefind-entry.json"
+min="${MIN_INDEXED_PAGES:-500}"
+
+if [ ! -f "$entry" ]; then
+    echo "::error::Pagefind index missing: $entry"
+    exit 1
+fi
+
+pages="$(jq '[.languages[].page_count] | add // 0' "$entry")"
+
+if [ "$pages" -lt "$min" ]; then
+    echo "::error::Pagefind indexed $pages pages, expected at least $min."
+    exit 1
+fi
+
+echo "Pagefind indexed $pages pages."

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -83,10 +83,28 @@ jobs:
         env:
           HUGO_ENVIRONMENT: production
           HUGO_PROCESS_IMAGES: "true"
-        run: hugo --templateMetrics --templateMetricsHints ${{ inputs.hugo-flags }}
+        run: |
+          set -o pipefail
+          hugo --templateMetrics --templateMetricsHints ${{ inputs.hugo-flags }} \
+            2>&1 | tee hugo-build.log
+
+      # Runs before the deploy so a warning-producing build is never published.
+      - name: Assert no Hugo warnings
+        run: .github/scripts/assert-no-hugo-warnings.sh hugo-build.log
 
       - name: Build search index
         run: yarn build-search
+
+      # A partial index exits 0, so check the page count rather than the status.
+      #
+      # The floor sits just under the measured count (3235 on 2026-08-04) so that
+      # losing any one indexed section trips it -- the smallest indexed section is
+      # software at ~367 pages. Bump this as content grows; the failure message
+      # prints the actual count, so the new value is whatever it reports.
+      - name: Assert search index is populated
+        env:
+          MIN_INDEXED_PAGES: "3000"
+        run: .github/scripts/assert-search-index.sh
 
       - name: Deploy to Netlify
         id: netlify

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ content/blog/_lychee/
 
 # Panache cache
 .panache-cache/
+
+# Build log captured for the CI no-warnings assert
+hugo-build.log

--- a/content/events/user-2026/_index.md
+++ b/content/events/user-2026/_index.md
@@ -45,14 +45,14 @@ Together, Posit Assistant and mcp-repl illustrate two ways to bring R’s intera
 We had an incredible time exploring Warsaw and chatting all things R!  Charlie had such a great time that he wrote a blog post on the experience:
 
 {{< insert-items format="card" hide-badge=true >}}
-- blog/2026-07-14_user-2026-warsaw/
+- blog/user-2026-warsaw/
 {{< /insert-items>}}
 
 {{< gallery title="Photos from the event" >}}
-- file: photos/user1.jpg
+- file: photos/user1.jpeg
   caption: "Opening reception"
-- file: photos/user2.jpg
+- file: photos/user2.jpeg
   caption: "Charlie's presentation"
-- file: photos/scipy3.jpeg
+- file: photos/user3.jpeg
   caption: "Group photo"
 {{< /gallery >}}


### PR DESCRIPTION
### Prerequisite check

- [x] **I have linked an approved GitHub Issue below.** (Required for all changes except minor typos/broken links).

### Related Issue

Closes #372. Also supersedes #370, whose content fix is included here verbatim.

### Description of changes

Per #372, the `build-and-deploy` job treated Hugo warnings as noise, so broken references scrolled past in the log and shipped to production. This adds two asserts, both **before** the Netlify step so a bad build is never published rather than flagged after it is already live:

1. **`Assert no Hugo warnings`** — the Hugo build is teed to a log (under `set -o pipefail`, so a genuine build failure isn't masked by the pipe) and `.github/scripts/assert-no-hugo-warnings.sh` fails on any `WARN`/`ERROR` line. `.github/hugo-warning-allowlist.txt` exists for warnings that genuinely can't be fixed; it starts empty and every entry needs a comment justifying it.

2. **`Assert search index is populated`** — Pagefind only exits non-zero when it indexes *nothing*. A partial index exits 0 and silently ships broken search, which matters here because `data-pagefind-body` is a **site-wide opt-in switch** spread across six layouts: drop it from `layouts/blog/single.html` and ~1,048 blog posts vanish from search with no other signal. The floor is set just under the measured count so losing any one indexed section trips it.

Because this workflow is `workflow_call`, both gates apply to preview and production deploys. A new warning will block a production deploy; the escape hatch is a line in the allowlist.

### Content fixes (supersedes #370)

The warnings gate immediately surfaced four real bugs live on the useR! 2026 event page, so this includes #370's fix verbatim:

- the `insert-items` slug pointed at `blog/2026-07-14_user-2026-warsaw/`, but the post lives at `content/blog/user-2026-warsaw/`, so the `site.GetPage` lookup failed and the blog card silently vanished
- three gallery photos used `.jpg` where the files on disk are `.jpeg`, one of them still a leftover `scipy3.jpeg` from a different event

### Verification

Verified locally against the exact Hugo version CI pins (extended **0.158.0**, not the newer Homebrew build):

| Check | Before | After |
|---|---|---|
| Hugo `WARN`/`ERROR` lines | 4 | **0** |
| Pagefind indexed pages | 3,235 | 3,235 (floor 3,000) |

The threshold was chosen from the measured count, not guessed. Simulated regressions confirm it bites:

| Scenario | Count | Result |
|---|---|---|
| Healthy | 3,235 | pass |
| `blog` section lost | 2,187 | **fail** |
| `software` section lost (smallest) | 2,868 | **fail** |

Both scripts were also unit-checked against clean logs, warning logs, missing logs, missing args, allowlisted-only, allowlisted-plus-new, empty index, sub-threshold, and missing index file. `shellcheck` is clean. Note the allowlist strips blanks and comments deliberately — a blank line in a `grep -Ff` pattern file matches *every* line and would silently suppress all warnings.

One gap in the local verification: the build was run without the `--buildFuture` flag that preview deploys pass, which pulls in future-dated content and could surface warnings the local run did not. CI on this PR is the authoritative check.

### Known limitation

The page-count floor won't catch the small sections (`people` ~59, `events` ~35) disappearing; no practical floor would. It is a guard against whole-section regressions, not a per-page ratchet. The floor needs bumping as content grows — the failure message prints the actual count, so the new value is whatever it reports.

### Note for reviewers

Separately discovered and **not addressed here**: Hugo **0.164.0 cannot build this site at all**, failing on a newer `security.allowContent` policy that rejects `content/blog/ported/great-tables/pycon-2024-great-tables-are-possible/table.html` (`"text/html" is not whitelisted`). Any future Hugo bump needs a `security.allowContent` config entry first. Worth its own issue if a Hugo upgrade is on the roadmap.

### Checklist

- [x] My code/content builds locally without errors or warnings.
- [x] I have verified that all links and code blocks function properly.
- [x] This contribution aligns with the project's `CONTRIBUTING.md` guidelines.