### PR TITLE
Fix Event and datetime issues from the Search Console structured data report

### DIFF
--- a/content/events/posit-conf-2025/_index.md
+++ b/content/events/posit-conf-2025/_index.md
@@ -6,6 +6,7 @@ start_date: 2025-09-16
 end_date: 2025-09-18
 image: posit-conf-2025.jpg
 website: https://posit.co/conference
+organizer: "Posit Software, PBC"
 description: "Our annual event brought together data enthusiasts, professionals, developers, and innovators for an unforgettable three days of learning, connection, and inspiration."
 languages:
 - R

--- a/content/events/posit-conf-2026/_index.md
+++ b/content/events/posit-conf-2026/_index.md
@@ -6,6 +6,7 @@ start_date: 2026-09-14
 end_date: 2026-09-16
 image: posit-conf-2026.png
 website: https://posit.co/conference
+organizer: "Posit Software, PBC"
 description: "Our annual event brings together data enthusiasts, professionals, developers, and innovators for an unforgettable three days of learning, connection, and inspiration."
 languages:
 - R

--- a/layouts/partials/jsonld.html
+++ b/layouts/partials/jsonld.html
@@ -106,6 +106,7 @@
           "@type" "Event"
           "name" .Title
           "url" .Permalink
+          "eventStatus" "https://schema.org/EventScheduled"
     -}}
     {{- with .Params.description -}}
       {{- $ld = merge $ld (dict "description" (. | plainify)) -}}
@@ -118,6 +119,11 @@
     {{- end -}}
     {{- with .Params.location -}}
       {{- $ld = merge $ld (dict "location" (dict "@type" "Place" "name" . "address" .)) -}}
+    {{- end -}}
+    {{- /* Opt-in: most events here are run by third parties, so only claim an
+           organizer when the front matter names one. */ -}}
+    {{- with .Params.organizer -}}
+      {{- $ld = merge $ld (dict "organizer" (dict "@type" "Organization" "name" .)) -}}
     {{- end -}}
     {{- with .Params.website -}}
       {{- $ld = merge $ld (dict "sameAs" (slice .)) -}}
@@ -139,7 +145,7 @@
       {{- $ld = merge $ld (dict "description" (. | plainify | truncate 5000)) -}}
     {{- end -}}
     {{- with .Date -}}
-      {{- $ld = merge $ld (dict "uploadDate" (.Format "2006-01-02")) -}}
+      {{- $ld = merge $ld (dict "uploadDate" (.Format "2006-01-02T15:04:05-07:00")) -}}
     {{- end -}}
     {{- with .Params.external.thumbnail -}}
       {{- $ld = merge $ld (dict "thumbnailUrl" .) -}}
@@ -170,7 +176,7 @@
       {{- $ld = merge $ld (dict "description" (. | plainify)) -}}
     {{- end -}}
     {{- with .Date -}}
-      {{- $ld = merge $ld (dict "datePublished" (.Format "2006-01-02")) -}}
+      {{- $ld = merge $ld (dict "datePublished" (.Format "2006-01-02T15:04:05-07:00")) -}}
     {{- end -}}
     {{- with .Params.image -}}
       {{- with $.Resources.Get . -}}


### PR DESCRIPTION
## What this responds to

Search Console emailed us **"Events structured data issues detected in posit.co"** listing four non-critical issues:

- Missing field `eventStatus`
- Missing field `organizer`
- Missing field `offers`
- Missing field `performer`

That alert is for the **`posit.co` domain property**, which covers subdomains — so it pools `posit.co` and `opensource.posit.co` together. Before writing any code I checked which site each issue actually comes from, by pulling the live Event JSON-LD from both:

| Source | `eventStatus` | `organizer` | `offers` | `performer` |
|---|---|---|---|---|
| `posit.co` (Drupal, 40 event pages sampled) | present | present | **missing 40/40** | **missing 40/40** |
| `opensource.posit.co` (this repo, 43 events) | **missing** | **missing** | **missing** | **missing** |

So `eventStatus` and `organizer` are ours — `posit.co` sets both on every page I sampled, meaning those two lines in the email can only be coming from this site. `offers` and `performer` were already being reported from `posit.co` before this site emitted any Event markup at all; #364 added 43 more pages to those two counts but didn't introduce them.

**This PR clears the two issues that originate on `opensource.posit.co`.**

## How it fixes them

### `eventStatus` — fixed for all 43 events

`layouts/partials/jsonld.html` now emits `"eventStatus": "https://schema.org/EventScheduled"` on every Event. Unconditional is the right call: no event has a cancelled or postponed field in its front matter, so all 43 are genuinely scheduled. If we ever need to mark one cancelled, it becomes a front matter lookup at that point.

### `organizer` — fixed for the 2 events we actually organize

This one deserves an explanation, because the obvious fix is the wrong one.

The tempting move is to set `organizer` to Posit Software, PBC everywhere and watch the warning count go to zero. But **most events on this site are other people's events** — we list them because Posit folks are speaking or teaching there. SDSS is the American Statistical Association's. PyCon US is the Python Software Foundation's. useR! is the R Foundation's. Declaring Posit as the organizer of all of them would be false structured data, which is a worse outcome than an unfilled optional field — Google treats misleading markup as a quality problem, not a neutral one.

So `organizer` is opt-in via front matter:

```yaml
organizer: "Posit Software, PBC"
```

Set here on `posit::conf(2025)` and `posit::conf(2026)`, which we unambiguously run. The other 41 events are left without it deliberately.

### `offers` and `performer` — not addressed, deliberately

`offers` needs real ticket pricing we don't have and mostly can't speak to for third-party events. `performer` isn't a meaningful concept for a conference. Both are optional. These two are also the pair that `posit.co` accounts for, so the counts in Search Console won't reach zero from this repo regardless.

## Also fixed: an invalid datetime Google was rejecting

While validating the above against Google's Rich Results Test, the video pages turned up a real error the email didn't mention:

> Invalid datetime value for "uploadDate"
> Datetime property "uploadDate" is missing a timezone

`VideoObject.uploadDate` was being emitted date-only (`2024-10-31`) instead of full ISO 8601. That affected **all 1,684 video pages**. Now `2024-10-31T00:00:00+00:00`, matching the format `BlogPosting` already used. The cheatsheet `LearningResource.datePublished` had the identical bug — Google doesn't flag it because `LearningResource` isn't a rich-result type, but it's fixed too.

Event `startDate`/`endDate` stay date-only; Google accepts that for Events and raised no warning on them.

## Verification

Full local rebuild, all JSON-LD extracted and parsed:

| Check | Before | After |
|---|---|---|
| Blocks parsed without error | 3,307 / 3,307 | 3,307 / 3,307 |
| Events missing `eventStatus` | 43 / 43 | **0 / 43** |
| Events with `organizer` | 0 | **2** (posit::conf only) |
| Videos with date-only `uploadDate` | 1,684 | **0** |
| Cheatsheets with date-only `datePublished` | 29 | **0** |

I also rebuilt with these changes stashed to confirm the diff is otherwise neutral — identical page counts and identical output for every other type.

## What to expect after deploy

Search Console reports lag behind recrawl, so the counts won't move immediately. Once Google recrawls, the `eventStatus` line should drop off entirely and `organizer` should fall by two. `offers` and `performer` will remain, driven mostly by `posit.co`. All four are non-critical throughout — nothing here was keeping pages out of search.

## Known gaps, not fixed here

Turned up during validation, all content rather than template problems:

- 225 blog posts with no `image`
- 12 blog posts with no `author`
- 9 videos with no `description` — these nine won't be eligible for video rich results until described

🤖 Generated with [Claude Code](https://claude.com/claude-code)
